### PR TITLE
Repairing a broken form builder definition

### DIFF
--- a/xml/mods_large_image.xml
+++ b/xml/mods_large_image.xml
@@ -1,201 +1,1203 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns:dms="http://dms.stanford.edu/ns/" xmlns:foaf="http://xmlns.com/foaf/0.1/"
-    xmlns:ore="http://www.openarchives.org/ore/terms/"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:oac="http://www.openannotation.org/ns/">
-    <rdf:Description
-        rdf:about="http://localhost/Development/fedora/repository/islandora:1366-002/AnnotationList">
-        <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-        <rdf:type rdf:resource="http://dms.stanford.edu/ns/AnnotationList"/>
-        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
-        <rdf:type rdf:resource="http://www.openarchives.org/ore/terms/Aggregation"/>
-    </rdf:Description>
-    <rdf:Description
-        rdf:about="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas">
-        <rdf:type rdf:resource="http://dms.stanford.edu/ns/Canvas"/>
-    </rdf:Description>
-    <rdf:Description
-        rdf:about="http://localhost/Development/emic/serve/islandora:1366-002/AnnotationList/AnnotationList.xml">
-        <ore:describes
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/AnnotationList"/>
-        <rdf:type rdf:resource=""/>
-        <dc:format>application/rdf+xml</dc:format>
-        <dcterms:modified>2012-04-13T13:56:53-03:00</dcterms:modified>
-    </rdf:Description>
-    <rdf:Description rdf:about=""/>
-    <rdf:Description rdf:about="urn:uuid:C5312BE4-A020-0001-A321-BC3FE46027E0">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/Annotation"/>
-        <oac:hasBody rdf:resource="urn:uuid:C5312BE4-A060-0001-E360-B19E113A141F"/>
-        <oac:hasTarget rdf:resource="urn:uuid:C5312BE4-A070-0001-68F8-929012DA1C78"/>
-        <dcterms:created>2012-04-13 16:57:59 UTC</dcterms:created>
-        <dc:title>Id Tag</dc:title>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5312BE4-A060-0001-E360-B19E113A141F">
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>this ID tag appears in the corner of the cover</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:uuid:C5312BE4-A070-0001-68F8-929012DA1C78">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/ConstrainedTarget"/>
-        <oac:constrains
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas"/>
-        <oac:constrainedBy rdf:resource="urn:uuid:C5312BE4-A070-0001-66DB-1F736C4D151F"/>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5312BE4-A070-0001-66DB-1F736C4D151F">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/SvgConstraint"/>
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>&lt;svg:rect xmlns:svg='http://www.w3.org/2000/svg' x='27.5' y='44.5' width='111'
-            height='132' r='0' rx='0' ry='0' fill='#ffbbff' stroke='#000000' style='opacity: 0.7;
-            stroke-width: 2;' opacity='0.7' stroke-width='2' &gt;&lt;/svg:rect&gt;</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about=""/>
-    <rdf:Description rdf:about="urn:uuid:C5312E15-A9B0-0001-CB50-845BB4949AA0">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/Annotation"/>
-        <oac:hasBody rdf:resource="urn:uuid:C5312E15-A9D0-0001-84A6-AB401BD0188C"/>
-        <oac:hasTarget rdf:resource="urn:uuid:C5312E15-A9E0-0001-D0E7-F990159D4180"/>
-        <dcterms:created>2012-04-13 17:36:17 UTC</dcterms:created>
-        <dc:title>Second Annotation</dc:title>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5312E15-A9D0-0001-84A6-AB401BD0188C">
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>This is a second annotation, whihc appears only for mapping purposes</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:uuid:C5312E15-A9E0-0001-D0E7-F990159D4180">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/ConstrainedTarget"/>
-        <oac:constrains
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas"/>
-        <oac:constrainedBy rdf:resource="urn:uuid:C5312E15-A9E0-0001-49AD-B05018BCE400"/>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5312E15-A9E0-0001-49AD-B05018BCE400">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/SvgConstraint"/>
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>&lt;svg:circle xmlns:svg='http://www.w3.org/2000/svg' cx='280.5' cy='317.5'
-            r='111' fill='#ffbbff' stroke='#000000' style='opacity: 0.7; stroke-width: 2;'
-            opacity='0.7' stroke-width='2' &gt;&lt;/svg:circle&gt;</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about=""/>
-    <rdf:Description rdf:about="urn:uuid:C5318615-F040-0001-C01C-165F62201EAE">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/Annotation"/>
-        <oac:hasBody rdf:resource="urn:uuid:C5318615-F080-0001-FE8C-5B70CD8011C7"/>
-        <oac:hasTarget rdf:resource="urn:uuid:C5318615-F090-0001-623E-FE90CFE0D430"/>
-        <dcterms:created>2012-04-14 19:14:13 UTC</dcterms:created>
-        <dc:title>Polygon</dc:title>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5318615-F080-0001-FE8C-5B70CD8011C7">
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>No more parrots</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:uuid:C5318615-F090-0001-623E-FE90CFE0D430">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/ConstrainedTarget"/>
-        <oac:constrains
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas"/>
-        <oac:constrainedBy rdf:resource="urn:uuid:C5318615-F090-0001-C252-41001010E180"/>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5318615-F090-0001-C252-41001010E180">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/SvgConstraint"/>
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>&lt;svg:path xmlns:svg='http://www.w3.org/2000/svg' fill='#ffbbff'
-            stroke='#000000' d='M460,158L469,214L682,265L674,165L539,141Z' style='opacity: 0.7;
-            stroke-width: 2;' opacity='0.7' stroke-width='2' &gt;&lt;/svg:path&gt;</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about=""/>
-    <rdf:Description rdf:about="urn:uuid:C531861E-FFF0-0001-CBFC-7EE0110AFDA0">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/Annotation"/>
-        <oac:hasBody rdf:resource="urn:uuid:C531861F-0020-0001-B029-129E12D03C60"/>
-        <oac:hasTarget rdf:resource="urn:uuid:C531861F-0030-0001-94E6-11DDA6BC89B0"/>
-        <dcterms:created>2012-04-14 19:14:50 UTC</dcterms:created>
-        <dc:title>New Square</dc:title>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C531861F-0020-0001-B029-129E12D03C60">
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>Square stuff</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:uuid:C531861F-0030-0001-94E6-11DDA6BC89B0">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/ConstrainedTarget"/>
-        <oac:constrains
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas"/>
-        <oac:constrainedBy rdf:resource="urn:uuid:C531861F-0030-0001-D3B0-16B099EB2000"/>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C531861F-0030-0001-D3B0-16B099EB2000">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/SvgConstraint"/>
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>&lt;svg:rect xmlns:svg='http://www.w3.org/2000/svg' x='391.5' y='149.5'
-            width='99' height='74' r='0' rx='0' ry='0' fill='#ffbbff' stroke='#000000'
-            style='opacity: 0.7; stroke-width: 2;' opacity='0.7' stroke-width='2'
-            &gt;&lt;/svg:rect&gt;</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about=""/>
-    <rdf:Description rdf:about="urn:uuid:C5318647-E620-0001-8E55-1BC311CD9990">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/Annotation"/>
-        <oac:hasBody rdf:resource="urn:uuid:C5318647-E660-0001-CD8B-12A01EA0157B"/>
-        <oac:hasTarget rdf:resource="urn:uuid:C5318647-E660-0001-80C8-18105B312EE0"/>
-        <dcterms:created>2012-04-14 19:17:38 UTC</dcterms:created>
-        <dc:title>One More</dc:title>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5318647-E660-0001-CD8B-12A01EA0157B">
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>Test of output</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:uuid:C5318647-E660-0001-80C8-18105B312EE0">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/ConstrainedTarget"/>
-        <oac:constrains
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas"/>
-        <oac:constrainedBy rdf:resource="urn:uuid:C5318647-E660-0001-9FD5-1510150D139F"/>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5318647-E660-0001-9FD5-1510150D139F">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/SvgConstraint"/>
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>&lt;svg:rect xmlns:svg='http://www.w3.org/2000/svg' x='68.5' y='187.5' width='65'
-            height='33' r='0' rx='0' ry='0' fill='#ffbbff' stroke='#000000' style='opacity: 0.7;
-            stroke-width: 2;' opacity='0.7' stroke-width='2' &gt;&lt;/svg:rect&gt;</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about=""/>
-    <rdf:Description rdf:about="urn:uuid:C5321DF1-9860-0001-3486-C6981A1112D1">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/Annotation"/>
-        <oac:hasBody rdf:resource="urn:uuid:C5321DF1-9870-0001-6B10-E3E01F209CA0"/>
-        <oac:hasTarget rdf:resource="urn:uuid:C5321DF1-9870-0001-3DFB-C74A1AC81DE0"/>
-        <dcterms:created>2012-04-16 15:28:08 UTC</dcterms:created>
-        <dc:title>trial</dc:title>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5321DF1-9870-0001-6B10-E3E01F209CA0">
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>test return</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:uuid:C5321DF1-9870-0001-3DFB-C74A1AC81DE0">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/ConstrainedTarget"/>
-        <oac:constrains
-            rdf:resource="http://localhost/Development/fedora/repository/islandora:1366-002/Canvas"/>
-        <oac:constrainedBy rdf:resource="urn:uuid:C5321DF1-9870-0001-6680-17DC19C2EB30"/>
-    </rdf:Description>
-    <rdf:Description xmlns:cnt="http://www.w3.org/2008/content#"
-        rdf:about="urn:uuid:C5321DF1-9870-0001-6680-17DC19C2EB30">
-        <rdf:type rdf:resource="http://www.openannotation.org/ns/SvgConstraint"/>
-        <rdf:type rdf:resource="http://www.w3.org/2008/content#ContentAsText"/>
-        <cnt:chars>&lt;svg:circle xmlns:svg='http://www.w3.org/2000/svg' cx='475.5' cy='214.5'
-            r='20' fill='#ffbbff' stroke='#000000' style='opacity: 0.7; stroke-width: 2;'
-            opacity='0.7' stroke-width='2' &gt;&lt;/svg:circle&gt;</cnt:chars>
-        <cnt:characterEncoding>utf-8</cnt:characterEncoding>
-    </rdf:Description>
-</rdf:RDF>
+<?xml version="1.0"?>
+<definition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2">
+    <properties>
+        <root_name>mods</root_name>
+        <schema_uri>http://www.loc.gov/standards/mods/v3/mods-3-4.xsd</schema_uri>
+        <namespaces default="http://www.loc.gov/mods/v3">
+            <namespace prefix="mods">http://www.loc.gov/mods/v3</namespace>
+            <namespace prefix="xsi">http://www.w3.org/2001/XMLSchema-instance</namespace>
+            <namespace prefix="xlink">http://www.w3.org/1999/xlink</namespace>
+        </namespaces>
+    </properties>
+    <form>
+        <properties>
+            <type>form</type>
+            <access>true</access>
+            <attributes>
+                <enctype>multipart/form-data</enctype>
+            </attributes>
+            <required>false</required>
+            <tree>true</tree>
+        </properties>
+        <children>
+            <element name="ingest-file-location">
+                <properties>
+                    <type>file</type>
+                    <access>true</access>
+                    <description>Select image to upload.</description>
+                    <required>false</required>
+                    <tree>true</tree>
+                </properties>
+                <children/>
+            </element>
+            <element name="titleInfo">
+                <properties>
+                    <type>markup</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>titleInfo</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:titleInfo</path>
+                            <context>document</context>
+                        </read>
+                        <update/>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children>
+                    <element name="title">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <description>Title of image.</description>
+                            <required>false</required>
+                            <title>Title</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>mods:titleInfo</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>title</value>
+                                </create>
+                                <read>
+                                    <path>mods:title</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                    <element name="subTitle">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Sub Title</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>subTitle</value>
+                                </create>
+                                <read>
+                                    <path>mods:subTitle</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                </children>
+            </element>
+            <element name="name">
+                <properties>
+                    <type>tabs</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Name</title>
+                    <tree>true</tree>
+                </properties>
+                <children>
+                    <element name="0">
+                        <properties>
+                            <type>tabpanel</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>/mods:mods</path>
+                                    <context>document</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>name</value>
+                                </create>
+                                <read>
+                                    <path>mods:name</path>
+                                    <context>document</context>
+                                </read>
+                                <update/>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children>
+                            <element name="type">
+                                <properties>
+                                    <type>select</type>
+                                    <access>true</access>
+                                    <default_value>personal</default_value>
+                                    <options>
+                                        <option key="corporate">corporate</option>
+                                        <option key="personal">personal</option>
+                                    </options>
+                                    <required>false</required>
+                                    <title>Type</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>attribute</type>
+                                            <prefix/>
+                                            <value>type</value>
+                                        </create>
+                                        <read>
+                                            <path>@type</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="namePart">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <required>false</required>
+                                    <title>Name</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>xml</type>
+                                            <prefix/>
+                                            <value>&lt;namePart&gt;%value%&lt;/namePart&gt;</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:namePart</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </delete>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="role">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Select a role from this vocabulary -
+                                        http://id.loc.gov/vocabulary/relators.html - e.g. Artist,
+                                        Creator, Designer, Engraver, Illustrator, Photographer,
+                                        Printmaker, etc.</description>
+                                    <required>false</required>
+                                    <title>Role</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>xml</type>
+                                            <prefix/>
+                                            <value>&lt;role&gt;&lt;roleTerm authority="marcrelator"
+                                                type="text"&gt;%value%&lt;/roleTerm&gt;&lt;/role&gt;</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:role/mods:roleTerm</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </delete>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                        </children>
+                    </element>
+                </children>
+            </element>
+            <element name="typeOfResource">
+                <properties>
+                    <type>select</type>
+                    <access>true</access>
+                    <default_value>still image</default_value>
+                    <options>
+                        <option key="text">text</option>
+                        <option key="cartographic">cartographic</option>
+                        <option key="notated music">notated music</option>
+                        <option key="sound recording">sound recording</option>
+                        <option key="sound recording-musical">sound recording-musical</option>
+                        <option key="sound recording-nonmusical">sound recording-nonmusical</option>
+                        <option key="moving image">moving image</option>
+                        <option key="three dimensional object">three dimensional object</option>
+                        <option key="software, multimedia">software, multimedia</option>
+                        <option key="mixed material">mixed material</option>
+                        <option key="still image">still image</option>
+                    </options>
+                    <required>false</required>
+                    <title>Type of Resource</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>typeOfResource</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:typeOfResource</path>
+                            <context>document</context>
+                        </read>
+                        <update/>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children/>
+            </element>
+            <element name="genre">
+                <properties>
+                    <type>textfield</type>
+                    <access>true</access>
+                    <description>A term that best describes the genre of the image. A excellent
+                        source for terms is the Thesaurus for Graphic Materials from the Library of
+                        Congress - http://www.loc.gov/pictures/collection/tgm/</description>
+                    <required>false</required>
+                    <title>Genre</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>xml</type>
+                            <prefix/>
+                            <value>&lt;genre authority="lctgm"&gt;%value%&lt;/genre&gt;</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:genre</path>
+                            <context>document</context>
+                        </read>
+                        <update>
+                            <path>self::node()</path>
+                            <context>self</context>
+                        </update>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children/>
+            </element>
+            <element name="originInfo">
+                <properties>
+                    <type>fieldset</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Origin Information</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>originInfo</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:originInfo</path>
+                            <context>document</context>
+                        </read>
+                        <update/>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children>
+                    <element name="dateCreated">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <description>Enter date in the format YYYY-MM-DD.</description>
+                            <required>false</required>
+                            <title>Date Created</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>dateCreated</value>
+                                </create>
+                                <read>
+                                    <path>mods:dateCreated</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                    <element name="publisher">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Publisher</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>publisher</value>
+                                </create>
+                                <read>
+                                    <path>mods:publisher</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                    <element name="country">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Country</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>xml</type>
+                                    <prefix/>
+                                    <value>&lt;place&gt;&lt;placeTerm authority='marccountry'
+                                        type='code'&gt;%value%&lt;/placeTerm&gt;&lt;/place&gt;</value>
+                                </create>
+                                <read>
+                                    <path>mods:place/mods:placeTerm[@type = 'code']</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                    <element name="place">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Place</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>xml</type>
+                                    <prefix/>
+                                    <value>&lt;place&gt;&lt;placeTerm
+                                        type="text"&gt;%value%&lt;/placeTerm&gt;&lt;/place&gt;</value>
+                                </create>
+                                <read>
+                                    <path>mods:place/mods:placeTerm[@type = 'text']</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                </children>
+            </element>
+            <element name="language">
+                <properties>
+                    <type>textfield</type>
+                    <access>true</access>
+                    <description>Select a three letter iso639-2b language code from &lt;a
+                        href="http://www.loc.gov/standards/iso639-2/php/code_list.php"
+                        target="_blank"&gt;http://www.loc.gov/standards/iso639-2/php/code_list.php&lt;/a&gt;</description>
+                    <required>false</required>
+                    <title>Language</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>xml</type>
+                            <prefix/>
+                            <value>&lt;language&gt;&lt;languageTerm authority="iso639-2b"
+                                type="code"&gt;%value%&lt;/languageTerm&gt;&lt;/language&gt;</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:language/mods:languageTerm</path>
+                            <context>document</context>
+                        </read>
+                        <update>
+                            <path>self::node()</path>
+                            <context>self</context>
+                        </update>
+                        <delete>
+                            <path>self::node()</path>
+                            <context>self</context>
+                        </delete>
+                    </actions>
+                </properties>
+                <children/>
+            </element>
+            <element name="abstract">
+                <properties>
+                    <type>textarea</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Description</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>abstract</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:abstract</path>
+                            <context>document</context>
+                        </read>
+                        <update>
+                            <path>self::node()</path>
+                            <context>self</context>
+                        </update>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children/>
+            </element>
+            <element name="identifier">
+                <properties>
+                    <type>textfield</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Identifier (local)</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>xml</type>
+                            <prefix/>
+                            <value>&lt;identifier type="local"&gt;%value%&lt;/identifier&gt;</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:identifier[@type='local']</path>
+                            <context>document</context>
+                        </read>
+                        <update>
+                            <path>self::node()</path>
+                            <context>self</context>
+                        </update>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children/>
+            </element>
+            <element name="physicalDescription">
+                <properties>
+                    <type>fieldset</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Physical Description</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>physicalDescription</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:physicalDescription</path>
+                            <context>document</context>
+                        </read>
+                        <update/>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children>
+                    <element name="form">
+                        <properties>
+                            <type>select</type>
+                            <access>true</access>
+                            <default_value>nonprojected graphic</default_value>
+                            <description>A designation of a particular physical presentation of a
+                                resource, including the physical form or medium of material for a
+                                resource.</description>
+                            <options>
+                                <option key="videorecording">videorecording</option>
+                                <option key="unspecified">unspecified</option>
+                                <option key="text">text</option>
+                                <option key="tactile material">tactile material</option>
+                                <option key="sound recording">sound recording</option>
+                                <option key="remote-sensing image">remote-sensing image</option>
+                                <option key="projected graphic">projected graphic</option>
+                                <option key="notated music">notated music</option>
+                                <option key="nonprojected graphic">nonprojected graphic</option>
+                                <option key="motion picture">motion picture</option>
+                                <option key="microform">microform</option>
+                                <option key="map">map</option>
+                                <option key="kit">kit</option>
+                                <option key="globe">globe</option>
+                                <option key="electronic resource">electronic resource</option>
+                            </options>
+                            <required>false</required>
+                            <title>Form</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>xml</type>
+                                    <prefix/>
+                                    <value>&lt;form
+                                        authority="marcform"&gt;%value%&lt;/form&gt;</value>
+                                </create>
+                                <read>
+                                    <path>mods:form</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                    <element name="extent">
+                        <properties>
+                            <type>textfield</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Extent</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>self::node()</path>
+                                    <context>parent</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>extent</value>
+                                </create>
+                                <read>
+                                    <path>mods:extent</path>
+                                    <context>parent</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children/>
+                    </element>
+                </children>
+            </element>
+            <element name="note">
+                <properties>
+                    <type>textarea</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Note</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>note</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:note[not(@*)]</path>
+                            <context>document</context>
+                        </read>
+                        <update>
+                            <path>self::node()</path>
+                            <context>self</context>
+                        </update>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children/>
+            </element>
+            <element name="subject">
+                <properties>
+                    <type>fieldset</type>
+                    <access>true</access>
+                    <required>false</required>
+                    <title>Subject</title>
+                    <tree>true</tree>
+                    <actions>
+                        <create>
+                            <path>/mods:mods</path>
+                            <context>document</context>
+                            <schema/>
+                            <type>element</type>
+                            <prefix/>
+                            <value>subject</value>
+                        </create>
+                        <read>
+                            <path>/mods:mods/mods:subject</path>
+                            <context>document</context>
+                        </read>
+                        <update/>
+                        <delete/>
+                    </actions>
+                </properties>
+                <children>
+                    <element name="topic">
+                        <properties>
+                            <type>tags</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Topic</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create/>
+                                <read/>
+                                <update/>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children>
+                            <element name="0">
+                                <properties>
+                                    <type>tag</type>
+                                    <access>true</access>
+                                    <required>false</required>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>/mods:mods/mods:subject</path>
+                                            <context>document</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>topic</value>
+                                        </create>
+                                        <read>
+                                            <path>/mods:mods/mods:subject/mods:topic</path>
+                                            <context>document</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </delete>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                        </children>
+                    </element>
+                    <element name="geographic">
+                        <properties>
+                            <type>tags</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Geographic</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create/>
+                                <read/>
+                                <update/>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children>
+                            <element name="0">
+                                <properties>
+                                    <type>tag</type>
+                                    <access>true</access>
+                                    <required>false</required>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>/mods:mods/mods:subject</path>
+                                            <context>document</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>geographic</value>
+                                        </create>
+                                        <read>
+                                            <path>/mods:mods/mods:subject/mods:geographic</path>
+                                            <context>document</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </delete>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                        </children>
+                    </element>
+                    <element name="temporal">
+                        <properties>
+                            <type>tags</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Temporal</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create/>
+                                <read/>
+                                <update/>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children>
+                            <element name="0">
+                                <properties>
+                                    <type>tag</type>
+                                    <access>true</access>
+                                    <required>false</required>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>/mods:mods/mods:subject</path>
+                                            <context>document</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>temporal</value>
+                                        </create>
+                                        <read>
+                                            <path>/mods:mods/mods:subject/mods:temporal</path>
+                                            <context>document</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </delete>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                        </children>
+                    </element>
+                    <element name="hierarchicalGeographic">
+                        <properties>
+                            <type>fieldset</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Geographic Information</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>/mods:mods/mods:subject</path>
+                                    <context>document</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>hierarchicalGeographic</value>
+                                </create>
+                                <read>
+                                    <path>/mods:mods/mods:subject/mods:hierarchicalGeographic</path>
+                                    <context>document</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children>
+                            <element name="continent">
+                                <properties>
+                                    <type>select</type>
+                                    <access>true</access>
+                                    <default_value>North America</default_value>
+                                    <options>
+                                        <option key="Asia">Asia</option>
+                                        <option key="Africa">Africa</option>
+                                        <option key="Europe">Europe</option>
+                                        <option key="North America">North America</option>
+                                        <option key="South America">South America</option>
+                                    </options>
+                                    <required>false</required>
+                                    <title>Continent</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>continent</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:continent</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="country">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Name of a country, i.e. a political entity
+                                        considered a country.</description>
+                                    <required>false</required>
+                                    <title>Country</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>country</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:country</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="province">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Includes first order political divisions called
+                                        provinces within a country, e.g. in Canada.</description>
+                                    <required>false</required>
+                                    <title>Province</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>province</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:province</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="region">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Includes regions that have status as a
+                                        jurisdiction, usually incorporating more than one first
+                                        level jurisdiction.</description>
+                                    <required>false</required>
+                                    <title>Region</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>region</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:region</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="county">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Name of the largest local administrative unit in
+                                        various countries, e.g. England.</description>
+                                    <required>false</required>
+                                    <title>County</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>county</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:county</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="city">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Name of an inhabited place incorporated as a city,
+                                        town, etc.</description>
+                                    <required>false</required>
+                                    <title>City</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>city</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:city</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                            <element name="citySection">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Name of a smaller unit within a populated place,
+                                        e.g., neighborhoods, parks, or streets.</description>
+                                    <required>false</required>
+                                    <title>City Section</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>citySection</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:citySection</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                        </children>
+                    </element>
+                    <element name="cartographics">
+                        <properties>
+                            <type>fieldset</type>
+                            <access>true</access>
+                            <required>false</required>
+                            <title>Cartographics</title>
+                            <tree>true</tree>
+                            <actions>
+                                <create>
+                                    <path>/mods:mods/mods:subject</path>
+                                    <context>document</context>
+                                    <schema/>
+                                    <type>element</type>
+                                    <prefix/>
+                                    <value>cartographics</value>
+                                </create>
+                                <read>
+                                    <path>/mods:mods/mods:subject/mods:cartographics</path>
+                                    <context>document</context>
+                                </read>
+                                <update>
+                                    <path>self::node()</path>
+                                    <context>self</context>
+                                </update>
+                                <delete/>
+                            </actions>
+                        </properties>
+                        <children>
+                            <element name="coordinates">
+                                <properties>
+                                    <type>textfield</type>
+                                    <access>true</access>
+                                    <description>Contains a statement of coordinates covered by the
+                                        resource.</description>
+                                    <required>false</required>
+                                    <title>Coordinates</title>
+                                    <tree>true</tree>
+                                    <actions>
+                                        <create>
+                                            <path>self::node()</path>
+                                            <context>parent</context>
+                                            <schema/>
+                                            <type>element</type>
+                                            <prefix/>
+                                            <value>coordinates</value>
+                                        </create>
+                                        <read>
+                                            <path>mods:coordinates</path>
+                                            <context>parent</context>
+                                        </read>
+                                        <update>
+                                            <path>self::node()</path>
+                                            <context>self</context>
+                                        </update>
+                                        <delete/>
+                                    </actions>
+                                </properties>
+                                <children/>
+                            </element>
+                        </children>
+                    </element>
+                </children>
+            </element>
+            <element name="submit">
+                <properties>
+                    <type>submit</type>
+                    <access>true</access>
+                    <tree>true</tree>
+                    <value>Submit</value>
+                </properties>
+                <children/>
+            </element>
+        </children>
+    </form>
+</definition>


### PR DESCRIPTION
It looks like the form builder definition was overwritten by some random rdf.  This was causing the vanilla form builder to fail on me when I tried to open the large image mods form.  I retrieved the most recent version of the working form from the git history and it doesn't crash for me anymore.
