### PR TITLE
Swapped out ImageMagick for Kakadu

### DIFF
--- a/admin/islandora_large_image.admin.inc
+++ b/admin/islandora_large_image.admin.inc
@@ -12,10 +12,81 @@
 function islandora_large_image_admin($form, &$form_state) {
   // include css
   drupal_add_css(drupal_get_path('module', 'islandora_large_image') . '/css/islandora_large_image.admin.css');
-  // include solution packs inc file
+
+  if (isset($form_state['values']['islandora_kakadu_url'])) {
+    $kakadu_url = $form_state['values']['islandora_kakadu_url'];
+  }
+  else {
+    $kakadu_url = variable_get('islandora_kakadu_url', '/usr/bin/kdu_compress');
+  }
+
+  $lossless = variable_get('islandora_lossless', FALSE);
+
+  $kakadu_checked = isset($form_state['values']['islandora_use_kakadu']) ? $form_state['values']['islandora_use_kakadu'] : variable_get('islandora_use_kakadu', FALSE);
+  $kakadu_view = $kakadu_checked ? 'markup' : 'hidden';
+
+
+  exec($kakadu_url, $output, $return_value);
+  $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>'
+      . t('kakadu executable found at !kakadu_url', array('!kakadu_url' => "<strong>$kakadu_url</strong>"));
+  if ($return_value != 0) {
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/> '
+        . t('Unable to find kakadu executable at !kakadu_url', array('!kakadu_url' => "<strong>$kakadu_url</strong>"));
+  }
+  $form = array();
+  $form['islandora_lossless'] = array(
+    '#title' => t("Lossless Derivative Creation?"),
+    '#default_value' => $lossless,
+    '#description' => t('Lossless derivative are of higher quality, but will adversely affect browser performance.'),
+    '#type' => 'checkbox',
+  );
+
+  $form['islandora_use_kakadu'] = array(
+    '#title' => t("Use Kakadu for image compression?"),
+    '#default_value' => $kakadu_checked,
+    '#description' => t("!kakadu offers faster derivative creation than the standard ImageMagick package.", array('!kakadu' => l(t('kakadu'), 'http://www.kakadusoftware.com/'))),
+    '#type' => 'checkbox',
+    '#ajax' => array(
+      'callback' => 'islandora_update_kakadu_url_div',
+      'wrapper' => 'islandora-url',
+      'effect' => 'fade',
+      'progress' => array('type' => 'throbber'),
+    ),
+  );
+
+  $forms['islandora_kakadu_url'] = array(
+    '#prefix' => '<div id = "kakadu_url">',
+    '#suffix' => '</div>',
+    '#type' => 'textfield',
+    '#description' => t("This module requires !kakadu to create derivative files", array('!kakadu' => l(t('kakadu'), 'http://www.kakadusoftware.com/'))),
+    '#default_value' => $kakadu_url,
+    '#size' => 20
+  );
+
+  // ajax wrapper for url checking
+  $form['wrapper'] = array(
+    '#prefix' => '<div id="islandora-url">',
+    '#suffix' => '</div>',
+    '#type' => $kakadu_view,
+  );
+
+  $form['wrapper']['islandora_kakadu_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t("Path to kakadu"),
+    '#default_value' => $kakadu_url,
+    '#description' => t('Path to kakadu <br /> !confirmation_message', array('!confirmation_message' => $confirmation_message)),
+    '#ajax' => array(
+      'callback' => 'islandora_update_kakadu_url_div',
+      'wrapper' => 'islandora-url',
+      'effect' => 'fade',
+      'event' => 'blur',
+      'progress' => array('type' => 'throbber'),
+    ),
+  );
+
   module_load_include('inc', 'islandora', 'includes/solution_packs');
 
-  $form = array();
+
   // get viewer table
   $viewer_table = islandora_viewers_form('islandora_large_image_viewers', 'image/jp2');
   // add viewer table
@@ -45,4 +116,11 @@ function islandora_large_image_admin_submit($form, &$form_state) {
       variable_del('islandora_large_image_viewers');
       break;
   }
+}
+
+function islandora_update_kakadu_url_div($form, $form_state) {
+  unset($form_state['submit_handlers']);
+  $form_state['rebuild'] = TRUE;
+
+  return $form['wrapper'];
 }

--- a/includes/islandora_large_image.process.inc
+++ b/includes/islandora_large_image.process.inc
@@ -64,17 +64,22 @@ function islandora_large_image_get_uploaded_file(FedoraObject $object, $base_nam
  */
 function islandora_large_image_create_JP2_derivative(FedoraObject $object, $uploaded_file, $base_name) {
   // create JP2 with kakadu
-  // $derivative_file = islandora_large_image_kdu_compress($uploaded_file, "temporary://{$base_name}_JP2.jp2"); // Create JP2
-  // create JP2 with ImageMagick - possibly make this switchable?
-  $args[] = " -define numrlvls=6";
-  $args[] = " -define jp2:tilewidth=1024";
-  $args[] = " -define jp2:tileheight=1024";
-  $args[] = " -define jp2:rate=1.0";
-  $args[] = " -define jp2:lazy";
-  $args[] = " -define jp2:prg=rlcp";
-  $args[] = " -define jp2:ilyrrates='0.015625,0.01858,0.0221,0.025,0.03125,0.03716,0.04419,0.05,0.0625, 0.075,0.088,0.1,0.125,0.15,0.18,0.21,0.25,0.3,0.35,0.4,0.5,0.6,0.7,0.84'";
-  $args[] = " -define jp2:mode=int";
-  $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JP2.jp2", $args);
+  $kakadu = variable_get('islandora_use_kakadu', FALSE);
+  $mime = strtolower($object['OBJ']->mimetype);
+  if ($mime == 'image/jpeg' || $mime == 'image/jpg') {
+    $kakadu = FALSE;
+  }
+
+  if ($kakadu) {
+    $derivative_file = islandora_large_image_kdu_compress($uploaded_file, "temporary://{$base_name}_JP2.jp2"); // Create JP2
+    if (!$derivative_file) {
+      drupal_set_message(t("Kakadu failed.  Trying ImageMagick"));
+      $kakadu = FALSE; //forces retry with IMageMagick if Kakadu has failed - allows compressed tiffs if unsupported by Kakadu version
+    }
+  }
+  if (!$kakadu) {
+    $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JP2.jp2", islandora_large_image_get_args());
+  }
   if ($derivative_file === FALSE) {
     drupal_set_message(t('Failed to create JP2 derivative'), 'error');
     return FALSE;
@@ -235,5 +240,36 @@ function islandora_large_image_add_datastream($object, $dsid, $file, $mimetype, 
   return TRUE;
 }
 
+/**
+ * Return preconfigured paramaters for ImageMagick JP2 creation
+ * @return array
+ *
+ */
 
+function islandora_large_image_get_args() {
 
+  if (variable_get('islandora_lossless', FALSE)) {
+    $args[] = " -define numrlvls=6";
+    $args[] = " -define jp2:tilewidth=1024";
+    $args[] = " -define jp2:tileheight=1024";
+    $args[] = " -define jp2:rate=1.0";
+    $args[] = " -define jp2:lazy";
+    $args[] = " -define jp2:prg=rlcp";
+    $args[] = " -define jp2:ilyrrates='0.015625,0.01858,0.0221,0.025,0.03125,0.03716,0.04419,0.05,0.0625, 0.075,0.088,0.1,0.125,0.15,0.18,0.21,0.25,0.3,0.35,0.4,0.5,0.6,0.7,0.84'";
+    $args[] = " -define jp2:mode=int";
+  }
+  else {
+    $args[] = "-define numrlvls=7";
+    $args[] = "-define jp2:tilewidth=1024";
+    $args[] = "-define jp2:tileheight=1024";
+    $args[] = "-define jp2:rate=0.02348";
+    $args[] = "-define jp2:prg=rpcl";
+    $args[] = "-define jp2:mode=int";
+    $args[] = "-define jp2:prcwidth=16383";
+    $args[] = "-define jp2:prcheight=16383";
+    $args[] = "-define jp2:cblkwidth=64";
+    $args[] = "-define jp2:cblkheight=64";
+    $args[] = "-define jp2:sop";
+  }
+  return $args;
+}

--- a/includes/islandora_large_image.process.inc
+++ b/includes/islandora_large_image.process.inc
@@ -63,7 +63,18 @@ function islandora_large_image_get_uploaded_file(FedoraObject $object, $base_nam
  *   TRUE if successful, FALSE otherwise.
  */
 function islandora_large_image_create_JP2_derivative(FedoraObject $object, $uploaded_file, $base_name) {
-  $derivative_file = islandora_large_image_kdu_compress($uploaded_file, "temporary://{$base_name}_JP2.jp2"); // Create JP2
+  // create JP2 with kakadu
+  // $derivative_file = islandora_large_image_kdu_compress($uploaded_file, "temporary://{$base_name}_JP2.jp2"); // Create JP2
+  // create JP2 with ImageMagick - possibly make this switchable?
+  $args[] = " -define numrlvls=6";
+  $args[] = " -define jp2:tilewidth=1024";
+  $args[] = " -define jp2:tileheight=1024";
+  $args[] = " -define jp2:rate=1.0";
+  $args[] = " -define jp2:lazy";
+  $args[] = " -define jp2:prg=rlcp";
+  $args[] = " -define jp2:ilyrrates='0.015625,0.01858,0.0221,0.025,0.03125,0.03716,0.04419,0.05,0.0625, 0.075,0.088,0.1,0.125,0.15,0.18,0.21,0.25,0.3,0.35,0.4,0.5,0.6,0.7,0.84'";
+  $args[] = " -define jp2:mode=int";
+  $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JP2.jp2", $args);
   if ($derivative_file === FALSE) {
     drupal_set_message(t('Failed to create JP2 derivative'), 'error');
     return FALSE;
@@ -86,7 +97,10 @@ function islandora_large_image_create_JP2_derivative(FedoraObject $object, $uplo
  *   TRUE if successful, FALSE otherwise.
  */
 function islandora_large_image_create_JPG_derivative(FedoraObject $object, $uploaded_file, $base_name) {
-  $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JPG.jpg", 600, 800);
+  $args = array();
+  $args[] = '-resize ' . escapeshellarg("600 x 800}");
+  $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
+  $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JPG.jpg", $args);
   if ($derivative_file === FALSE) {
     drupal_set_message(t('Failed to create JPG derivative'), 'error');
     return FALSE;
@@ -109,7 +123,10 @@ function islandora_large_image_create_JPG_derivative(FedoraObject $object, $uplo
  *   TRUE if successful, FALSE otherwise.
  */
 function islandora_large_image_create_TN_derivative(FedoraObject $object, $uploaded_file, $base_name) {
-  $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_TN.jpg", 200, 200);
+  $args = array();
+  $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
+  $args[] = '-resize ' . escapeshellarg("200 x 200");
+  $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_TN.jpg", $args);
   if ($derivative_file === FALSE) {
     drupal_set_message(t('Failed to create TN derivative'), 'error');
     return FALSE;
@@ -148,7 +165,6 @@ function islandora_large_image_kdu_compress($src, $dest, $args = NULL) {
   return $dest;
 }
 
-
 /**
  * Calls imagemagick's convert command with the given arguments.
  *
@@ -164,11 +180,9 @@ function islandora_large_image_kdu_compress($src, $dest, $args = NULL) {
  * @return string
  *   The destination file path if successful otherwise FALSE.
  */
-function islandora_large_image_imagemagick_convert($src, $dest, $width, $height) {
+function islandora_large_image_imagemagick_convert($src, $dest, $args) {
   $src = drupal_realpath($src) . '[0]';
   $dest = drupal_realpath($dest);
-  $args['quality'] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
-  $args['previewsize'] = '-resize ' . escapeshellarg("{$width}x{$height}");
   $context = array(
     'source' => $src,
     'destination' => $dest,
@@ -220,3 +234,6 @@ function islandora_large_image_add_datastream($object, $dsid, $file, $mimetype, 
   }
   return TRUE;
 }
+
+
+


### PR DESCRIPTION
OnTime task 157.  By switching to ImageMagick we can use uncompressed tifs and jpegs as source files
.
