### PR TITLE
add support for imagemagick with graphicsMagick

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -297,27 +297,12 @@ function islandora_large_image_kdu_compress($src, $dest, $args = NULL) {
  *   The destination file path if successful otherwise FALSE.
  */
 function islandora_large_image_imagemagick_convert($src, $dest, $args) {
-  $src = drupal_realpath($src) . '[0]';
-  $dest = drupal_realpath($dest);
-  $context = array(
-    'source' => $src,
-    'destination' => $dest,
-  );
-  drupal_alter('imagemagick_arguments', $args, $context);
-
-  // To make use of ImageMagick 6's parenthetical command grouping we need to
-  // make the $source image the first parameter and $dest the last.
-  // See http://www.imagemagick.org/Usage/basics/#cmdline
-  $command = escapeshellarg($src) . ' ' . implode(' ', $args) . ' ' . escapeshellarg($dest);
-  $output = '';
-  $ret = -1;
-  if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {
+  if (_imagemagick_convert($src, $dest, $args) !== TRUE) {
     $variables = array(
-      '@ret' => $ret,
-      '@command' => $command,
-      '!output' => implode('<br/>', $output),
+      '@ret' => $src,
+      '@command' => $dest,
     );
-    watchdog('islandora_large_image', 'ImageMagick failed to convert.<br/>Error: @ret<br/>Command: @command <br/>Output !output', $variables, WATCHDOG_ERROR);
+    watchdog('islandora_large_image', 'ImageMagick failed to convert. @src to @dest', $variables, WATCHDOG_ERROR);
     return FALSE;
   }
   return $dest;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -14,21 +14,15 @@ function islandora_large_image_check_imagemagick_for_jpeg2000() {
   $supports =& drupal_static(__FUNCTION__);
 
   if ($supports === NULL) {
-    $command_output = NULL;
-
-    $e = exec(escapeshellcmd(variable_get('imagemagick_convert', 'convert')) . " -list format", $command_output);
-    $filtered = preg_filter("/.*JP2.*JPEG-2000\s+File\s+Format\s+Syntax/", "\\0", $command_output);
-    $supports = FALSE;
-    foreach ($filtered as $f) {
-      $s = array();
-      if (preg_match_all('/([r-][w-].)/', $f, $s)) {
-        if (strpos($s[1][0], 'w') !== FALSE) {
-          $supports = TRUE;
-          break;
-        }
-      }
+    $command = variable_get('imagemagick_convert', 'convert');
+    if (variable_get('imagemagick_gm', 0)) {
+      $command .= ' convert';
     }
+    $command .= " -list format";
+    $command_output = NULL;
+    $e = exec($command, $command_output);
+    $filtered = preg_filter("/.*JP2.*rw.*JPEG-2000/", "\\0", $command_output);
+    $supports = !empty($filtered);
   }
-
   return $supports;
 }


### PR DESCRIPTION
these two commits clean up code and add support for gm.  graphicsMagick is a fork of imagemagick with improved performance.

After completing this fix I was able to ingest 400mb tif without issues.

to use/test graphicsMagick support
apt-get install graphicsmagick-imagemagick-compat
in module ImageMagick change convert path to /usr/bin/gm and check graphicsMagick support.
