### PR TITLE
Windows-compatibility: Calling Kakadu through the command line

### DIFF
--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -9,6 +9,7 @@
  * Implements hook_requirements().
  */
 function islandora_large_image_requirements($phase) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $requirements = array();
   if ($phase == 'install') {
     $t = get_t();
@@ -17,8 +18,8 @@ function islandora_large_image_requirements($phase) {
 
     $command = 'command -v kdu_compress >/dev/null 2>&1';
 
-    // Determine if the server is running Windows.
-    if (islandora_os_check() == "Windows") {
+    // Determine if the server's operating system is Windows.
+    if (islandora_deployed_on_windows()) {
       // slangerx: Make this command Windows-friendly.
       $command = 'kdu_compress >NUL 2>&1';
     }

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -20,9 +20,10 @@ function islandora_large_image_requirements($phase) {
 
     // Determine if the server is running Windows.
     if (islandora_os_check() == "Windows") {
-      // slangerx, 2013-09-09: To make this command Windows-friendly, "command -v"
-      // should go away (it's Linux-specific). Also, "/dev/null" should be replaced
-      // with "NUL", which is the equivalent Null Device Driver in Windows.
+      // slangerx, 2013-09-09: To make this command Windows-friendly,
+      // "command -v" should go away (it's Linux-specific). Also,
+      // "/dev/null" should be replaced with "NUL", which is the
+      // equivalent Null Device Driver in Windows.
       $command = 'kdu_compress >NUL 2>&1';
     }
 

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -14,7 +14,20 @@ function islandora_large_image_requirements($phase) {
     $t = get_t();
     $out = array();
     $ret = 1;
-    exec('command -v kdu_compress >/dev/null 2>&1', $out, $ret);
+
+    // Updated: slangerx, 2013-09-09
+    $command = 'command -v kdu_compress >/dev/null 2>&1';
+
+    // Determine if the server is running Windows.
+    if (islandora_os_check() == "Windows") {
+      // slangerx, 2013-09-09: To make this command Windows-friendly, "command -v"
+      // should go away (it's Linux-specific). Also, "/dev/null" should be replaced
+      // with "NUL", which is the equivalent Null Device Driver in Windows.
+      $command = 'kdu_compress >NUL 2>&1';
+    }
+
+    exec($command, $out, $ret);
+
     if ($ret != 0) {
       $requirements['kakadu'] = array(
         'title' => $t("Kakadu Image Compression"),

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -20,7 +20,7 @@ function islandora_large_image_requirements($phase) {
 
     // Determine if the server's operating system is Windows.
     if (islandora_deployed_on_windows()) {
-      // slangerx: Make this command Windows-friendly.
+      // Update the command so it's Windows-friendly.
       $command = 'kdu_compress >NUL 2>&1';
     }
 

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -18,9 +18,7 @@ function islandora_large_image_requirements($phase) {
 
     $command = 'command -v kdu_compress >/dev/null 2>&1';
 
-    // Determine if the server's operating system is Windows.
     if (islandora_deployed_on_windows()) {
-      // Update the command so it's Windows-friendly.
       $command = 'kdu_compress >NUL 2>&1';
     }
 

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -15,15 +15,11 @@ function islandora_large_image_requirements($phase) {
     $out = array();
     $ret = 1;
 
-    // Updated: slangerx, 2013-09-09
     $command = 'command -v kdu_compress >/dev/null 2>&1';
 
     // Determine if the server is running Windows.
     if (islandora_os_check() == "Windows") {
-      // slangerx, 2013-09-09: To make this command Windows-friendly,
-      // "command -v" should go away (it's Linux-specific). Also,
-      // "/dev/null" should be replaced with "NUL", which is the
-      // equivalent Null Device Driver in Windows.
+      // slangerx: Make this command Windows-friendly.
       $command = 'kdu_compress >NUL 2>&1';
     }
 


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

When Kakadu is being called through the command line, some of the syntax is very Linux-specific and fails under Windows. This patch ensures the appropriate syntax is used based on the server's operating system.

To elaborate: 

> `command -v kdu_compress >/dev/null 2>&1` contains some Windows-incompatibilities. To make it more Windows-friendly, "command -v" should go away. Also, "/dev/null" should be replaced with "NUL", which is the equivalent Null Device Driver in Windows. As a result, the Windows equivalent of that command is: `kdu_compress >NUL 2>&1`

_NOTE:_ The function _islandora_deployed_on_windows()_ is introduced here: https://github.com/Islandora/islandora/pull/450
