### PR TITLE
Escape the file path shell parameter for identify.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -47,7 +47,7 @@ function islandora_large_image_get_bit_depth($file_uri) {
   if (file_exists($file_uri)) {
     $file_path = drupal_realpath($file_uri);
     $identify = islandora_large_image_get_identify();
-    return exec(escapeshellcmd("$identify -format %[depth] $file_path"));
+    return exec(escapeshellcmd("$identify -format %[depth] " . escapeshellarg($file_path)));
   }
   else {
     return FALSE;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1890
- Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

None.
# What does this Pull Request do?

Properly escape shell arguments for the **identity** command.
# What's new?

Just a small fix, shouldn't have any negative side effects.
# How should this be tested?

To verify the issue exists, test against an image placed in two folders:
- One with no spaces in the file path.
- One with spaces in the file path.

**For example:**

``` php
module_load_include('inc', 'islandora_large_image', 'includes/utilities');
// Note function currently works if path does not contain whitespace.
$image = drupal_realpath('/tmp/view.jp2');
$depth = islandora_large_image_get_bit_depth($image);
dsm($depth, 'Bit Depth (no spaces)');
$image = drupal_realpath('/tmp/test folder/view.jp2');
$depth = islandora_large_image_get_bit_depth($image);
dsm($depth, 'Bit Depth (with spaces)');
```

**Yields (Without the fix):**

> Bit Depth (no spaces) => 8
> Bit Depth (with spaces) => 

**Yields (With the fix):**

> Bit Depth (no spaces) => 8
> Bit Depth (with spaces) => 8

@Islandora/7-x-1-x-committers
