### PR TITLE
ISLANDORA-1853: escapeshellarg() for identify commands

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -63,7 +63,7 @@ function islandora_large_image_create_jp2_derivative(AbstractObject $object, $fo
       if (!$lossless) {
         $identify = islandora_large_image_get_identify();
         // Define all these variables in one call for a large performance gain.
-        $file_path = escapeshellarg(drupal_realpath($uploaded_file));
+        $file_path = drupal_realpath($uploaded_file);
         list($height, $width, $y_resolution, $x_resolution) = explode(
           ',',
           exec(escapeshellcmd("$identify -format \"%h,%W,%y,%x\" $file_path"))

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -63,7 +63,7 @@ function islandora_large_image_create_jp2_derivative(AbstractObject $object, $fo
       if (!$lossless) {
         $identify = islandora_large_image_get_identify();
         // Define all these variables in one call for a large performance gain.
-        $file_path = drupal_realpath($uploaded_file);
+        $file_path = escapeshellarg(drupal_realpath($uploaded_file));
         list($height, $width, $y_resolution, $x_resolution) = explode(
           ',',
           exec(escapeshellcmd("$identify -format \"%h,%W,%y,%x\" $file_path"))
@@ -469,7 +469,7 @@ function islandora_large_image_get_args($lossless) {
 function islandora_large_image_is_uncompressed_tiff($file) {
   $identify = islandora_large_image_get_identify();
 
-  $file = drupal_realpath($file);
+  $file = escapeshellarg(drupal_realpath($file));
 
   $compression = exec(escapeshellcmd("$identify -format \"%C\" $file"));
 
@@ -490,7 +490,7 @@ function islandora_large_image_is_uncompressed_tiff($file) {
 function islandora_large_image_is_tiff($file) {
   $identify = islandora_large_image_get_identify();
 
-  $file = drupal_realpath($file);
+  $file = escapeshellarg(drupal_realpath($file));
 
   $codec = exec(escapeshellcmd("$identify -format \"%m\" $file"));
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1853

# What does this Pull Request do?

Wraps references to files in imagemagick identify functions to use `escapeshellarg()`

# What's new?

Previously, in the two referenced spots in the code change, the entire command was being run through `escapeshellcmd()` - however, each command also contained a reference to a file, which `escapeshellcmd()` cannot properly account for. This meant that the command could fail, making it possible for the functions to return a false negative.

Each of these file references have been wrapped in `escapeshellarg()` to make sure they account for spaces or other escape-required characters.

# How should this be tested?

Sadly, it won't work to just run an ingest test, since that doesn't trigger the conditions for this.

`islandora_large_image_is_tiff()` and `islandora_large_image_is_jp2()` can be tested sort of the same way:

* Create a .tiff file (perhaps on an Islandora VM) that contains a space, either in the filename or in the path leading up to it. One is included in this module in the tests/fixtures folder; I just used that. It should be a valid TIFF image.
* (Download and?) enable the devel module on the machine
* Navigate to /devel/php in your browser
* Run the following code, replacing the path where it says to do so with the path to your .tiff file:

```php
module_load_include('inc', 'islandora_large_image', 'includes/derivatives');
$tiff = '/path/to/tiff with/space.tiff'; // REPLACE ME
$is_tiff = islandora_large_image_is_tiff($tiff);
dpm($is_tiff ? 'it is a tiff' : 'it is not a tiff');
```

Using the old code, Imagemagick identify fails no matter what and reports that it is not a tiff. Using the new code, Imagemagick correctly identifies that the file is a tiff.

The same basic process can be done with JP2s; there's even one in the tests/fixtures folder.

# Interested parties
@ajstanley would be the maintainer here.