### PR TITLE
separating escapeshellcmd and escapeshellarg

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -45,9 +45,9 @@ function islandora_large_image_check_imagemagick_for_jpeg2000() {
 function islandora_large_image_get_bit_depth($file_uri) {
   module_load_include('inc', 'islandora_large_image', 'includes/derivatives');
   if (file_exists($file_uri)) {
-    $file_path = drupal_realpath($file_uri);
+    $file_path = escapeshellarg(drupal_realpath($file_uri));
     $identify = islandora_large_image_get_identify();
-    return exec(escapeshellcmd("$identify -format %[depth] " . escapeshellarg($file_path)));
+    return exec(escapeshellcmd("$identify -format %[depth] ") . $file_path);
   }
   else {
     return FALSE;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1890 (re-opened)

# What does this Pull Request do?

Quick fix for https://github.com/Islandora/islandora_solution_pack_large_image/pull/159 - one problem was traded for another, so to speak; paths with spaces were resolved, but paths with other escape-required characters now see issues.

# What's new?

The portions of `islandora_large_image_get_bit_depth()` requiring `escapeshellarg()` and `escapeshellcmd()` have been separated to take advantage of the two different types of escaping required.

This is because those commands do two types of escaping - `escapeshellcmd()` creates backslashes in necessary spots, and `escapeshellarg()` places the argument in single quotes. Combining these together gets you backslash-escaped arguments surrounded by single quotes, which is double escaped and breaks.

# How should this be tested?

You can basically use the same test case from #159, but use a file with a naming convention like `/path/to/file(1).jpg` instead of the given one with spaces.

# Interested parties
@nigelgbanks @DonRichards and @dannylamb were there for the last pull
