### PR TITLE
Only escape arg, and only local to function.

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -471,7 +471,7 @@ function islandora_large_image_is_uncompressed_tiff($file) {
 
   $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $compression = exec(escapeshellcmd("$identify -format \"%C\"") . $escaped_file);
+  $compression = exec(escapeshellcmd("$identify -format \"%C\" ") . $escaped_file);
 
   $compressed = (strtolower($compression) != 'none');
 
@@ -492,7 +492,7 @@ function islandora_large_image_is_tiff($file) {
 
   $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $codec = exec(escapeshellcmd("$identify -format \"%m\"") . $escaped_file);
+  $codec = exec(escapeshellcmd("$identify -format \"%m\" ") . $escaped_file);
 
   $is_tiff = strrpos(strtolower($codec), 'tiff');
 
@@ -518,7 +518,7 @@ function islandora_large_image_is_jp2($file) {
 
   $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $codec = exec(escapeshellcmd("$identify -format \"%m\"") . $escaped_file);
+  $codec = exec(escapeshellcmd("$identify -format \"%m\" ") . $escaped_file);
 
   $is_jp2 = (strtolower($codec) == 'jp2');
 

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -469,9 +469,9 @@ function islandora_large_image_get_args($lossless) {
 function islandora_large_image_is_uncompressed_tiff($file) {
   $identify = islandora_large_image_get_identify();
 
-  $file = escapeshellarg(drupal_realpath($file));
+  $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $compression = exec(escapeshellcmd("$identify -format \"%C\" $file"));
+  $compression = exec(escapeshellcmd("$identify -format \"%C\"") . $escaped_file);
 
   $compressed = (strtolower($compression) != 'none');
 
@@ -490,9 +490,9 @@ function islandora_large_image_is_uncompressed_tiff($file) {
 function islandora_large_image_is_tiff($file) {
   $identify = islandora_large_image_get_identify();
 
-  $file = escapeshellarg(drupal_realpath($file));
+  $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $codec = exec(escapeshellcmd("$identify -format \"%m\" $file"));
+  $codec = exec(escapeshellcmd("$identify -format \"%m\"") . $escaped_file);
 
   $is_tiff = strrpos(strtolower($codec), 'tiff');
 
@@ -516,9 +516,9 @@ function islandora_large_image_is_tiff($file) {
 function islandora_large_image_is_jp2($file) {
   $identify = islandora_large_image_get_identify();
 
-  $file = drupal_realpath($file);
+  $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $codec = exec(escapeshellcmd("$identify -format \"%m\" $file"));
+  $codec = exec(escapeshellcmd("$identify -format \"%m\"") . $escaped_file);
 
   $is_jp2 = (strtolower($codec) == 'jp2');
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1898

# What does this Pull Request do?

Use of `escapeshellarg` was mixed with `escapeshellcmd` in a couple functions and then the escaped argument was passed to another function where it was escaped again. 

This caused (in my case) the variable to evaluate to nothing.

# What's new?

Output escaped file path as a new variable, use that variable outside of the `escapeshellcmd` call. Don't pass the escaped file path to subsequent functions.

# How should this be tested?

In our situation this manifested when creating a JP2 derivative from a Tiff, so I would suggest trying that.

The identify process in [islandora_large_image_is_tiff](https://github.com/Islandora/islandora_solution_pack_large_image/blob/7.x/includes/derivatives.inc#L495) is called from [islandora_large_image_is_uncompressed_tiff](https://github.com/Islandora/islandora_solution_pack_large_image/blob/7.x/includes/derivatives.inc#L478) with a value already escaped.

When it is escaped a second time, our value became `''` which meant that identify was not given an argument. It didn't seem to exit, but rather wait.

This PR isolates the escaped file path to each function and ensures that the variable escaped by `escapeshellarg` is not re-escaped by `escapeshellcmd`.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? np
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? I hope so

# Interested parties
@nigelgbanks @qadan - as they have more experience with escapeshellarg, in case I have missed something.

