### PR TITLE
7.x islandora 1071

### DIFF
--- a/islandora_large_image.module
+++ b/islandora_large_image.module
@@ -149,9 +149,9 @@ function islandora_large_image_islandora_sp_large_image_cmodel_islandora_view_ob
 }
 
 /**
- * Implements hook_preprocess().
+ * Implements template_preprocess_HOOK().
  */
-function islandora_large_image_preprocess_islandora_large_image(&$variables) {
+function template_preprocess_islandora_large_image(&$variables) {
   drupal_add_js('misc/form.js');
   drupal_add_js('misc/collapse.js');
   $islandora_object = $variables['islandora_object'];


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1071

# What does this Pull Request do?

This pull request ensures that when a function in this module implements hook_theme() that the template_preprocess hook is called to allow overriding variables further down the processing chain.

# What's new?

The function name has been changed to begin with ‘template’ instead of islandora_solution_pack_large_image.

# Interested parties