### PR TITLE
Added an option to convert source image to RGB-8 before derivative creation

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -31,6 +31,13 @@ function islandora_large_image_admin(array $form, array &$form_state) {
       '#default_value' => $get_default_value('islandora_lossless', FALSE),
       '#description' => t('Lossless derivatives are of higher quality but adversely affect browser performance.'),
     ),
+    'islandora_convert_rgb8' => array(
+      '#type' => 'checkbox',
+      '#title' => t("If source is less than 8 bit, convert it to RGB 8 bit prior to creating JP2 datastreams"),
+      '#default_value' => $get_default_value('islandora_convert_rgb8', FALSE),
+      '#description' => t('Normalization of source images by converting to an uncompressed RGB 8-bit depth TIFF for processing.  ' . 
+                          'This does not replace the original source datastream, but only makes a copy of it for derivative generation.'),
+    ),
     // Defaults to trying to use Kakadu if ImageMagick does not support JP2Ks.
     'islandora_use_kakadu' => array(
       '#type' => 'checkbox',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -35,8 +35,7 @@ function islandora_large_image_admin(array $form, array &$form_state) {
       '#type' => 'checkbox',
       '#title' => t("If source is less than 8 bit, convert it to RGB 8 bit prior to creating JP2 datastreams"),
       '#default_value' => $get_default_value('islandora_convert_rgb8', FALSE),
-      '#description' => t('Normalization of source images by converting to an uncompressed RGB 8-bit depth TIFF for processing.  ' . 
-                          'This does not replace the original source datastream, but only makes a copy of it for derivative generation.'),
+      '#description' => t('Normalization of source images by converting to an uncompressed RGB 8-bit depth TIFF for processing.  This does not replace the original source datastream, but only makes a copy of it for derivative generation.'),
     ),
     // Defaults to trying to use Kakadu if ImageMagick does not support JP2Ks.
     'islandora_use_kakadu' => array(

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -39,6 +39,7 @@ function islandora_large_image_get_uploaded_file(AbstractObject $object) {
 function islandora_large_image_create_jp2_derivative(AbstractObject $object, $force = TRUE) {
   module_load_include('inc', 'islandora_large_image', 'includes/utilities');
   $base_name = str_replace(':', '-', $object->id);
+  $normalized_src = '';
   if ($force || !isset($object['JP2'])) {
     $to_return = array(
       'success' => FALSE,
@@ -72,6 +73,18 @@ function islandora_large_image_create_jp2_derivative(AbstractObject $object, $fo
           ($height < 1024 || $width < 1024)) {
           $lossless = TRUE;
         }
+      }
+
+      if (variable_get('islandora_convert_rgb8', FALSE) && $depth < 8) {
+        // Make a copy of the source that can change
+        $uploaded_file = str_replace("temporary://", file_directory_temp() . '/', $uploaded_file);
+        $normalized_src = file_create_filename(drupal_basename($uploaded_file) . ".tif", file_directory_temp());
+        $normalized_src = str_replace("temporary://", file_directory_temp() . '/', $normalized_src);
+        $convert_command = 'convert ' . $uploaded_file . ' -compress None -resample 300x300 -depth 8 ' . $normalized_src;
+        $output = array();
+        exec($convert_command, $output, $ret);
+        @unlink($uploaded_file);
+        $uploaded_file = $normalized_src;
       }
 
       if ($kakadu) {
@@ -134,6 +147,9 @@ function islandora_large_image_create_jp2_derivative(AbstractObject $object, $fo
     }
     file_unmanaged_delete($uploaded_file);
     file_unmanaged_delete($derivative_file);
+    if ($normalized_src) {
+      file_unmanaged_delete($normalized_src);
+    }
     return $to_return;
   }
 }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -76,7 +76,7 @@ function islandora_large_image_create_jp2_derivative(AbstractObject $object, $fo
       }
 
       if (variable_get('islandora_convert_rgb8', FALSE) && $depth < 8) {
-        // Make a copy of the source that can change
+        // Make a copy of the source that can change.
         $uploaded_file = str_replace("temporary://", file_directory_temp() . '/', $uploaded_file);
         $normalized_src = file_create_filename(drupal_basename($uploaded_file) . ".tif", file_directory_temp());
         $normalized_src = str_replace("temporary://", file_directory_temp() . '/', $normalized_src);


### PR DESCRIPTION
**JIRA Ticket**: (link)
"JP2 derivatives have artifacts when source TIF is lower than 8-bit depth" https://jira.duraspace.org/browse/ISLANDORA-2042

# What does this Pull Request do?
When the source TIF is lower than 8-bit, the kakadu library does not generate the JPEG 2000 correctly.  In our experience, it was causing a grey rectangle artifact.  This should provide an option to make a copy of the source that can be turned into a good JPEG 2000 for those source files.  FWIW, the option to "Create Lossless Derivatives" will also make a good looking JP2, but the file size can be more than 10x larger than compressed files.

# What's new?
* added an additional option in admin/islandora/solution_pack_config/large_image for "Convert source to RGB 8 bit prior to creating JP2 datastreams" 
* adjusted the code based off of this configuration in the includes/derivatives.inc "islandora_large_image_create_jp2_derivative" function.

# How should this be tested?
* make an empty TIF file that can represent a basic scan of a white page.  Export the TIF as a 1-bit depth file.
* create a new islandora_large_image_sp_cmodel and use the 1-bit depth TIF from above as the OBJ.
* observe the JP2 derivative in the web viewer (depending on your islandora configuration) or by downloading and using a viewer for JP2 files
* now change the option in the Large Image Solution Pack config so that "Convert source to RGB 8 bit prior to creating JP2 datastreams" is set.
* navigate to the original object's Manage | Datastreams page, and click the JP2's "regenerate" derivative link.
* observe as above to see that the JP2 image has been derived without any bad artifact


# Additional Notes:
Use the JIRA ticket's attached TIF file for testing.
