### PR TITLE
ISLANDORA-1825 Update islandora_large_image_form_mods.xml

### DIFF
--- a/xml/islandora_large_image_form_mods.xml
+++ b/xml/islandora_large_image_form_mods.xml
@@ -354,6 +354,42 @@
           </actions>
         </properties>
         <children>
+          <element name="dateIssued">
+            <properties>
+              <type>textfield</type>
+              <access>TRUE</access>
+              <collapsed>FALSE</collapsed>
+              <collapsible>FALSE</collapsible>
+              <description>Enter date in the format YYYY-MM-DD.</description>
+              <disabled>FALSE</disabled>
+              <executes_submit_callback>FALSE</executes_submit_callback>
+              <multiple>FALSE</multiple>
+              <required>FALSE</required>
+              <resizable>FALSE</resizable>
+              <title>Date Issued</title>
+              <tree>TRUE</tree>
+              <actions>
+                <create>
+                  <path>self::node()</path>
+                  <context>parent</context>
+                  <schema/>
+                  <type>element</type>
+                  <prefix>NULL</prefix>
+                  <value>dateIssued</value>
+                </create>
+                <read>
+                  <path>mods:dateIssued</path>
+                  <context>parent</context>
+                </read>
+                <update>
+                  <path>self::node()</path>
+                  <context>self</context>
+                </update>
+                <delete>NULL</delete>
+              </actions>
+            </properties>
+            <children/>
+          </element>
           <element name="dateCreated">
             <properties>
               <type>textfield</type>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1825

* Other Relevant Links: related to https://jira.duraspace.org/browse/ISLANDORA-1824 and islandora/islandora_solution_pack_pdf#132

# What does this Pull Request do?

Adds the dateIssued element to the default Large Image MODS form, as requested by the Metadata Interest Group (see JIRA ticket).

# How should this be tested?

Verify the elements are included in the right place and map properly.

This is an improvement, so no 7x-1.10 branch pull.

# Interested parties
@bondjimbond since he tested and merged the other one 😄 
