### PR TITLE
Make sure thumbnails are in the RGB colorspace.

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -220,6 +220,7 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
     $args = array();
     $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
     $args[] = '-resize ' . escapeshellarg("200 x 200");
+    $args[] = '-colorspace RGB';
     $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_TN.jpg", $args);
     if ($derivative_file === FALSE) {
       $to_return['messages'][] = array(


### PR DESCRIPTION
## JIRA Ticket

Release pull for: #176 
https://jira.duraspace.org/browse/ISLANDORA-2103

## What does this Pull Request do?

If a CMYK image is uploaded to the large image solution pack, the thumbnail that we produce will not be viewable in IE/Edge since it can't display jpeg with a CMKY color space. 

## What's new? 

Update the derivative generation function to make sure the thumbnail is in RGB color space. Should work the same as before if the image was already RGB.

## How should this be tested?

Upload a source image that is CMYK, for example this image:
[CMYK TIFF.zip](https://github.com/Islandora/islandora_solution_pack_large_image/files/1428234/CMYK.TIFF.zip)

Thumbnail generated before this patch shouldn't be viewable in IE/Edge

## Interested parties
@Islandora/7-x-1-x-committers @DiegoPino 