### PR TITLE
Add new viewer params for ISLANDORA-2097.

### DIFF
--- a/islandora_large_image.module
+++ b/islandora_large_image.module
@@ -205,8 +205,12 @@ function template_preprocess_islandora_large_image(&$variables) {
       array(
         'absolute' => TRUE,
         'query' => array('token' => $token),
-      ));
-    // Display large image.
+      )
+    );
+    $params['token'] = $token;
+    $params['pid'] = $islandora_object->id;
+    $params['dsid'] = 'JP2';
+    // Can be removed after 7.x-1.11 is out the door islandora_deprecated.
     $params['jp2_url'] = $jp2_url;
   }
 


### PR DESCRIPTION
## JIRA Ticket
https://jira.duraspace.org/browse/ISLANDORA-2123

Related to: 
https://github.com/Islandora/islandora_openseadragon/pull/90
https://github.com/Islandora/islandora_solution_pack_book/pull/200
https://github.com/Islandora/islandora_solution_pack_newspaper/pull/156

## What does this Pull Request do?

Adds the new parameters (`token`, `pid` and `dsid`) that `Islandora OpenSeadragon` expects to see passed to its viewer function. 

## How should this be tested?

Test with https://github.com/Islandora/islandora_openseadragon/pull/90 merged. After applying this patch there should be no deprecation warnings shown when viewing large images.

## Additional Notes:

Made note in code so additional deprecated parameter can be removed in the future.

## Interested parties

@qadan @ajstanley 