### PR TITLE
ISLANDORA-2154: Colorspace change on TN generation normalisation

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -228,8 +228,8 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
       $args = array();
       $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
       $args[] = '-resize ' . escapeshellarg("200 x 200");
-      $isRGB = stripos($colorspace, 'rgb');
-      if ($isRGB === FALSE) {
+      $isrgb = stripos($colorspace, 'rgb');
+      if ($isrgb === FALSE) {
         $args[] = '-colorspace sRGB';
       }
       $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_TN.jpg", $args);

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -2,8 +2,7 @@
 
 /**
  * @file
- * This file contains all the functions for image manipulation used in the large
- * image solution pack.
+ * This file contains image manipulation functions used in the large image SP.
  */
 
 /**
@@ -216,38 +215,50 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
     );
 
     $uploaded_file = islandora_large_image_get_uploaded_file($object);
-
-    $args = array();
-    $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
-    $args[] = '-resize ' . escapeshellarg("200 x 200");
-    $args[] = '-colorspace RGB';
-    $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_TN.jpg", $args);
-    if ($derivative_file === FALSE) {
+    $colorspace = islandora_large_image_get_colorspace($uploaded_file);
+    if ($colorspace === FALSE) {
       $to_return['messages'][] = array(
-        'message' => t('Failed to create TN derivative.'),
+        'message' => t('Failed to create TN derivative. Could not identify source OBJ.'),
         'type' => 'watchdog',
         'severity' => WATCHDOG_WARNING,
       );
     }
     else {
-      $added_successfully = islandora_large_image_add_datastream($object, 'TN', $derivative_file, 'image/jpeg', t('Thumbnail'));
-      if (TRUE === $added_successfully) {
+      // Only apply colorspace changes if not in the RGB family.
+      $args = array();
+      $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
+      $args[] = '-resize ' . escapeshellarg("200 x 200");
+      $isRGB = stripos($colorspace, 'rgb');
+      if ($isRGB === FALSE) {
+        $args[] = '-colorspace sRGB';
+      }
+      $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_TN.jpg", $args);
+      if ($derivative_file === FALSE) {
         $to_return['messages'][] = array(
-          'message' => t('Created TN derivative.'),
-          'type' => 'dsm',
-          'severity' => 'status',
+          'message' => t('Failed to create TN derivative.'),
+          'type' => 'watchdog',
+          'severity' => WATCHDOG_WARNING,
         );
-        $to_return['success'] = TRUE;
       }
       else {
-        $to_return['messages'][] = array(
-          'message' => t('Failed to add TN derivative to the object. Error message: @message', array('@message' => $added_successfully)),
-          'type' => 'dsm',
-          'severity' => 'warning',
-        );
+        $added_successfully = islandora_large_image_add_datastream($object, 'TN', $derivative_file, 'image/jpeg', t('Thumbnail'));
+        if (TRUE === $added_successfully) {
+          $to_return['messages'][] = array(
+            'message' => t('Created TN derivative.'),
+            'type' => 'dsm',
+            'severity' => 'status',
+          );
+          $to_return['success'] = TRUE;
+        }
+        else {
+          $to_return['messages'][] = array(
+            'message' => t('Failed to add TN derivative to the object. Error message: @message', array('@message' => $added_successfully)),
+            'type' => 'dsm',
+            'severity' => 'warning',
+          );
+        }
       }
     }
-
     file_unmanaged_delete($uploaded_file);
     file_unmanaged_delete($derivative_file);
     return $to_return;
@@ -261,7 +272,7 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
  * provided.
  *
  * @param string $src
- *   The source file to pass to kdu_compress
+ *   The source file to pass to kdu_compress.
  * @param string $dest
  *   The destination file which kdu_compress will generate.
  * @param string $args
@@ -526,6 +537,25 @@ function islandora_large_image_is_jp2($file) {
   return $is_jp2;
 }
 
+/**
+ * Uses Imagemagick's identify to get the colorspace of a file.
+ *
+ * @param string $file
+ *   A file-system path to the file in question.
+ *
+ * @return string|bool
+ *   The colorspace of the image if exists, or FALSE if
+ *   identify command exists/fails with 1.
+ */
+function islandora_large_image_get_colorspace($file) {
+  $identify = islandora_large_image_get_identify();
+
+  $escaped_file = escapeshellarg(drupal_realpath($file));
+
+  $colorspace = exec(escapeshellcmd("$identify -format %[colorspace] -regard-warnings ") . $escaped_file, $output, $procret);
+
+  return !$procret ? $colorspace : FALSE;
+}
 
 /**
  * Attempt to get the "identify" executable...
@@ -540,7 +570,7 @@ function islandora_large_image_get_identify() {
   // Get path for convert.
   $convert = variable_get('imagemagick_convert', 'convert');
 
-  // Replace "convert" with "identify"
+  // Replace "convert" with "identify".
   $identify = str_replace('convert', 'identify', $convert);
 
   return $identify;
@@ -548,8 +578,6 @@ function islandora_large_image_get_identify() {
 
 /**
  * Legacy function until derivative regeneration is fully flushed out for UI.
- *
- * @TODO: This is legacy functionality need to remove and update it.
  *
  * @param AbstractObject $object
  *   The object to add derivatives to.
@@ -559,6 +587,8 @@ function islandora_large_image_get_identify() {
  *
  * @return bool
  *   TRUE if all derivatives were created successfully, FALSE otherwise.
+ *
+ * @TODO: This is legacy functionality need to remove and update it.
  */
 function islandora_large_image_create_all_derivatives(AbstractObject $object, $force = TRUE) {
   if (!isset($object['OBJ'])) {


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2154](https://jira.duraspace.org/browse/ISLANDORA-2154)

* https://groups.google.com/forum/#!topic/islandora/kMOsaR1vcOY/discussion

# What does this Pull Request do?

Only applies ```-colorspace``` modifier to TN ```convert``` call if needed. Fixes issue with some image TN getting very dark.

# What's new?
Not much. Other than checking via ```identify``` for the existing colorspace and dealing with any possible exceptions there (mostly checking the exit code of the program, nothing fancy) it now drops TN creation if ```identify```command  is not able to run at all.

# How should this be tested?

Ingest a new Large Image object using this [image](http://doh.arcabc.ca/islandora/object/sicamous:60/datastream/OBJ/view)
Check your Thumbnail (should be dark)

Apply this pull
Ingest a new Large Image object using this [image](http://doh.arcabc.ca/islandora/object/sicamous:60/datastream/OBJ/view)
Check your Thumbnail (should be Ok)
Regenerate the TN
should be Ok.

Please test also with CMYK images, and JP2 sources if possible. The more testing the less the blame that will go to me if something fails! :smile:

# Additional Notes:

Future work would require that identify/and interrupting derivative generation happens when actually loading from OBJ at ```islandora_large_image_get_uploaded_file``` to avoid any unnecessary processing.

* Does this change require documentation to be updated? No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# Interested parties
 @Islandora/7-x-1-x-committers @jonathangreen