### PR TITLE
ISLANDORA-2154: Don't fail on TN generation if Source OBJ throws warnings

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -552,7 +552,7 @@ function islandora_large_image_get_colorspace($file) {
 
   $escaped_file = escapeshellarg(drupal_realpath($file));
 
-  $colorspace = exec(escapeshellcmd("$identify -format %[colorspace] -regard-warnings ") . $escaped_file, $output, $procret);
+  $colorspace = exec(escapeshellcmd("$identify -quiet -format %[colorspace] ") . $escaped_file, $output, $procret);
 
   return !$procret ? $colorspace : FALSE;
 }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2154](https://jira.duraspace.org/browse/ISLANDORA-2154)

* https://groups.google.com/forum/#!topic/islandora/kMOsaR1vcOY/discussion
* https://github.com/Islandora/islandora_solution_pack_large_image/pull/180#pullrequestreview-97891780

# What does this Pull Request do?

it fixes my misbehaved strictness. (my bad)
Removes the `-regards-warnings` flag when identifying an OBJ datastream because when encountering warnings like not standard TIFF tags TN derivative generation would fail completely.

# What's new?
Not much. Feel better now. thanks for asking

# How should this be tested?

Ingest a new Large Image object using this [image](http://doh.arcabc.ca/islandora/object/enderby:431/datastream/OBJ/view)
Check your Thumbnail (should be unexistant)

Apply this pull
Ingest a new Large Image object using this [image](http://doh.arcabc.ca/islandora/object/enderby:431/datastream/OBJ/view)
Check your Thumbnail (should be there)
Regenerate the TN
should be Ok.

Please test also with weird CMYK images, and non standard JP2 sources if possible to be sure i'm not breaking this even more. **I repeat** The more testing the less the blame that will go to me if something fails! :smile:

# Additional Notes:

* Does this change require documentation to be updated? No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# Interested parties
 @Islandora/7-x-1-x-committers @bondjimbond @willtp87 