### PR TITLE
ISLANDORA-2245: Relax requirement on Kakadu

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ This module requires the following modules/libraries:
 
 * [Islandora](https://github.com/islandora/islandora)
 * [Tuque](https://github.com/islandora/tuque)
-* [ImageMagick](https://drupal.org/project/imagemagick)
-* Kakadu (bundled with Djatoka)
+* [ImageMagick](https://drupal.org/project/imagemagick) (for `TN` and `JPG`
+    derivative generation)
 
-*To successfully create derivative data streams, ImageMagick (for TN & JPG) and Kakadu (for JP2) need to be installed on the server.*
+For JP2 derivative generation, we require at least one of:
+* Kakadu (bundled with Djatoka)
+* Imagemagick with JPEG 2000 support
 
 ## Installation
 
@@ -24,7 +26,6 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 Configure the image-toolkit to use ImageMagick rather than GD in Administration > Configuration > Media > Image Toolkit (admin/config/media/image-toolkit). If GD is selected, TN and JPG datastreams will not be generated.
 
 ![Configuration](https://camo.githubusercontent.com/6ae64673716ddf1f58d0e4856d7d7a5d79845506/687474703a2f2f692e696d6775722e636f6d2f4f33735150654f2e706e67)
-
 
 Select configuration options and viewer in Administration > Islandora > Large Image Collection (admin/islandora/large_image).
 

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -12,7 +12,6 @@ function islandora_large_image_requirements($phase) {
   $requirements = array();
   $t = get_t();
 
-
   if (in_array($phase, array('install', 'runtime'))) {
     $has_kakadu = _islandora_large_image_install_has_kakadu();
     $has_jp2_imagemagick = _islandora_large_image_install_has_imagemagick_with_jpeg2000_support();

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -9,31 +9,91 @@
  * Implements hook_requirements().
  */
 function islandora_large_image_requirements($phase) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
   $requirements = array();
-  if ($phase == 'install') {
-    $t = get_t();
-    $out = array();
-    $ret = 1;
+  $t = get_t();
 
-    $command = 'command -v kdu_compress >/dev/null 2>&1';
 
-    if (islandora_deployed_on_windows()) {
-      $command = 'kdu_compress >NUL 2>&1';
+  if (in_array($phase, array('install', 'runtime'))) {
+    $has_kakadu = _islandora_large_image_install_has_kakadu();
+    $has_jp2_imagemagick = _islandora_large_image_install_has_imagemagick_with_jpeg2000_support();
+    if ($has_kakadu) {
+      $requirements['islandora_large_image_kakadu'] = array(
+        'title' => $t("Islandora Solution Pack Large Image: Kakadu Image Compression"),
+        'value' => $t("Installed"),
+        'severity' => REQUIREMENT_INFO,
+        'description' => $t('The kdu_compress executable is accessible.'),
+      );
     }
-
-    exec($command, $out, $ret);
-
-    if ($ret != 0) {
-      $requirements['kakadu'] = array(
-        'title' => $t("Kakadu Image Compression"),
+    else {
+      $requirements['islandora_large_image_kakadu'] = array(
+        'title' => $t("Islandora Solution Pack Large Image: Kakadu Image Compression"),
+        'value' => $t("Not installed"),
+        'severity' => REQUIREMENT_INFO,
+        'description' => $t('The kdu_compress executable is not accessible.'),
+      );
+    }
+    if ($has_jp2_imagemagick) {
+      $requirements['islandora_large_image_imagemagick'] = array(
+        'title' => $t("Islandora Solution Pack Large Image: Imagemagick Image Compression"),
+        'value' => $t("Installed"),
+        'severity' => REQUIREMENT_INFO,
+        'description' => $t('Imagemagick is present and appears to support JPEG2000.'),
+      );
+    }
+    else {
+      $requirements['islandora_large_image_imagemagick'] = array(
+        'title' => $t("Islandora Solution Pack Large Image: Imagemagick Image Compression"),
+        'value' => $t("Not installed"),
+        'severity' => REQUIREMENT_INFO,
+        'description' => $t('Imagemagick does not appears to support JPEG2000.'),
+      );
+    }
+    if (!($has_kakadu || $has_jp2_imagemagick)) {
+      $requirements['islandora_large_image_encoder'] = array(
+        'title' => $t("Islandora Solution Pack Large Image: JPEG 2000 image encoder"),
         'value' => $t("Not installed"),
         'severity' => REQUIREMENT_WARNING,
-        'description' => $t('Ensure that adore-djatoka is installed and that kdu_compress is accessible by PHP.'),
+        'description' => $t('A JPEG 2000 encoder is not installed/configured.'),
+      );
+    }
+    else {
+      $requirements['islandora_large_image_encoder'] = array(
+        'title' => $t("Islandora Solution Pack Large Image: JPEG 2000 image encoder"),
+        'value' => $t("Installed"),
+        'severity' => REQUIREMENT_OK,
+        'description' => $t('A JPEG 2000 encoder is installed.'),
       );
     }
   }
   return $requirements;
+}
+
+/**
+ * Helper to test if Kakadu appears to be available.
+ */
+function _islandora_large_image_install_has_kakadu() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $out = array();
+  $ret = 1;
+
+  $command = 'command -v kdu_compress >/dev/null 2>&1';
+
+  if (islandora_deployed_on_windows()) {
+    $command = 'kdu_compress >NUL 2>&1';
+  }
+
+  exec($command, $out, $ret);
+
+  return $ret == 0;
+}
+
+/**
+ * Helper to test that imagemagick appears to have JPEG 2000 support.
+ */
+function _islandora_large_image_install_has_imagemagick_with_jpeg2000_support() {
+  require_once __DIR__ . '/includes/utilities.inc';
+  return islandora_large_image_check_imagemagick_for_jpeg2000();
 }
 
 /**

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -28,7 +28,7 @@ function islandora_large_image_requirements($phase) {
       $requirements['kakadu'] = array(
         'title' => $t("Kakadu Image Compression"),
         'value' => $t("Not installed"),
-        'severity' => REQUIREMENT_ERROR,
+        'severity' => REQUIREMENT_WARNING,
         'description' => $t('Ensure that adore-djatoka is installed and that kdu_compress is accessible by PHP.'),
       );
     }

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -51,7 +51,7 @@ function islandora_large_image_requirements($phase) {
       $requirements['islandora_large_image_encoder'] = array(
         'title' => $t("Islandora Solution Pack Large Image: JPEG 2000 image encoder"),
         'value' => $t("Not installed"),
-        'severity' => REQUIREMENT_WARNING,
+        'severity' => REQUIREMENT_ERROR,
         'description' => $t('A JPEG 2000 encoder is not installed/configured.'),
       );
     }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORAA-2245](https://jira.duraspace.org/browse/ISLANDORA-2245)

# What does this Pull Request do?

Relax requirement on Kakadu, since things can be done without it.

# What's new?

It is now possible to enable the module without Kakadu installed; however, to do so, imagemagick must support JPEG 2000.

# How should this be tested?

On a machine without Kakadu and with ImageMagick compiled with JPEG 2000 support, it is possible to enable this module.

# Additional Notes:

* Does this change require documentation to be updated? Yes.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Unknown... unlikely?

# Interested parties

Tagging @ajstanley as component manager.
