### PR TITLE
ISLANDORA-2306 Delete all this module's variables.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -97,7 +97,14 @@ function islandora_large_image_admin_submit($form, &$form_state) {
   $op = $form_state['clicked_button']['#id'];
   switch ($op) {
     case 'edit-reset':
-      variable_del('islandora_large_image_viewers');
+      $variables = array(
+        'islandora_large_image_viewers',
+        'islandora_use_kakadu',
+        'islandora_lossless',
+        'islandora_large_image_uncompress_tiff',
+        'islandora_kakadu_url',
+      );
+      array_walk($variables, 'variable_del');
       break;
   }
 }

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -117,6 +117,6 @@ function islandora_large_image_uninstall() {
     'islandora_lossless',
     'islandora_large_image_uncompress_tiff',
     'islandora_kakadu_url',
-    );
+  );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_large_image.install
+++ b/islandora_large_image.install
@@ -111,6 +111,12 @@ function islandora_large_image_install() {
 function islandora_large_image_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_large_image', 'uninstall');
-  $variables = array('islandora_large_image_viewers');
+  $variables = array(
+    'islandora_large_image_viewers',
+    'islandora_use_kakadu',
+    'islandora_lossless',
+    'islandora_large_image_uncompress_tiff',
+    'islandora_kakadu_url',
+    );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2306

# What does this Pull Request do?

Causes the "Reset" button on the admin form, and the uninstall hook, to clean up all variables. 

# How should this be tested?

Try to reset saved values to their defaults with the reset button in the Large Images admin form - other than the viewer, it won't work. 

Same with uninstalling the module. 

With this PR, they should be removed.

# Additional Notes:

* Does this change require documentation to be updated?  No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? 
**These variables are named generically - possibly a hangover from 6x, but they might be used elsewhere in other modules. They don't appear to be anywhere else in the Vagrant install, though. 

# Interested parties
@Islandora/7-x-1-x-committers
