### PR TITLE
ISLANDORA-2334 Add variables for TN & MED

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Of
 ####  To change the size of the thumbnail and medium size image derivatives
 These are handled as maximum sizes (retains original x to y ratio) and does not crop.
 
-```shell 
+```shell
 # For thumbnail size
 drush vset derivative_tn_size "200 x 200"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Select configuration options and viewer in Administration > Islandora > Large Im
 
 To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Often users will create symbolic links from `/usr/local/bin/kdu_compress` to their installation of Kakadu that comes bundled with [Adore-Djatoka](http://sourceforge.net/apps/mediawiki/djatoka/index.php?title=Installation). If the executable resides elsewhere on the server and no soft link has been created, be sure to provide the full path to the executable on the configuration page. Make sure that the required dynamic libraries that come with Kakadu are accessible to `kdu_compress` and `kdu_expand`. If they are not present, attempting to run either command from the terminal will inform you that the libraries are missing. You can also use a symbolic link from `/usr/local/lib` to include these libraries. Remember to restart the terminal so your changes take affect. Also, make sure the php settings allow for enough memory and upload size: `upload_max_filesize`, `post_max_size` and `memory_limit`.
 
-![Configuration](https://user-images.githubusercontent.com/2738244/49761778-f5dc9200-fc95-11e8-9892-12b1edf4a987.png)
+![Configuration](https://user-images.githubusercontent.com/2738244/49874645-fe93ac00-fdec-11e8-80ac-258759225d39.png)
 
 #### Width & Height
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Select configuration options and viewer in Administration > Islandora > Large Im
 
 To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Often users will create symbolic links from `/usr/local/bin/kdu_compress` to their installation of Kakadu that comes bundled with [Adore-Djatoka](http://sourceforge.net/apps/mediawiki/djatoka/index.php?title=Installation). If the executable resides elsewhere on the server and no soft link has been created, be sure to provide the full path to the executable on the configuration page. Make sure that the required dynamic libraries that come with Kakadu are accessible to `kdu_compress` and `kdu_expand`. If they are not present, attempting to run either command from the terminal will inform you that the libraries are missing. You can also use a symbolic link from `/usr/local/lib` to include these libraries. Remember to restart the terminal so your changes take affect. Also, make sure the php settings allow for enough memory and upload size: `upload_max_filesize`, `post_max_size` and `memory_limit`.
 
-![Configuration](https://camo.githubusercontent.com/3730f86cd795d7d989e1cbb9b5dfca5221228379/687474703a2f2f692e696d6775722e636f6d2f625335706834412e706e67)
+![Configuration](https://user-images.githubusercontent.com/2738244/49761778-f5dc9200-fc95-11e8-9892-12b1edf4a987.png)
 
 
 ####  To change the size of the thumbnail and medium size image derivatives

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Of
 
 ![Configuration](https://camo.githubusercontent.com/3730f86cd795d7d989e1cbb9b5dfca5221228379/687474703a2f2f692e696d6775722e636f6d2f625335706834412e706e67)
 
+
+####  To change the size of the thumbnail and medium size image derivatives
+These are handled as maximum sizes (retains original x to y ratio) and does not crop.
+
+```shell 
+# For thumbnail size
+drush vset derivative_tn_size "200 x 200"
+
+# For Medium sized JPEG size
+drush vset derivative_med_size "600 x 800"
+```
+To remove
+```shell
+# For thumbnail size
+drush vdel derivative_tn_size
+
+# For Medium sized JPEG size
+drush vdel derivative_med_size
+```
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Large+Image+Solution+Pack).

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Of
 
 ![Configuration](https://user-images.githubusercontent.com/2738244/49761778-f5dc9200-fc95-11e8-9892-12b1edf4a987.png)
 
-#### THUMBNAIL Width & Height
+#### Width & Height
+
 These are handled as maximum sizes (retains original x to y ratio) and does not crop. These values are shared with the [PDF Solution Pack](http://localhost:8000/admin/islandora/solution_pack_config/pdf).
-
-
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,25 +33,10 @@ To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Of
 
 ![Configuration](https://user-images.githubusercontent.com/2738244/49761778-f5dc9200-fc95-11e8-9892-12b1edf4a987.png)
 
+#### THUMBNAIL Width & Height
+These are handled as maximum sizes (retains original x to y ratio) and does not crop. These values are shared with the [PDF Solution Pack](http://localhost:8000/admin/islandora/solution_pack_config/pdf).
 
-####  To change the size of the thumbnail and medium size image derivatives
-These are handled as maximum sizes (retains original x to y ratio) and does not crop.
 
-```shell
-# For thumbnail size
-drush vset derivative_tn_size "200 x 200"
-
-# For Medium sized JPEG size
-drush vset derivative_med_size "600 x 800"
-```
-To remove
-```shell
-# For thumbnail size
-drush vdel derivative_tn_size
-
-# For Medium sized JPEG size
-drush vdel derivative_med_size
-```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To use Kakadu, make sure that `kdu_compress` is available to the Apache user. Of
 
 #### Width & Height
 
-These are handled as maximum sizes (retains original x to y ratio) and does not crop. These values are shared with the [PDF Solution Pack](http://localhost:8000/admin/islandora/solution_pack_config/pdf).
+These are handled as maximum sizes (retains original x to y ratio) and does not crop. These values are shared with the PDF Solution Pack (admin/islandora/solution_pack_config/pdf).
 
 ## Documentation
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -75,21 +75,62 @@ function islandora_large_image_admin(array $form, array &$form_state) {
         ),
       ),
     ),
-    'derivative_med_size' => array(
-      '#type' => 'textfield',
-      '#title' => t('Derivative Medium Size'),
-      '#default_value' => $get_default_value('derivative_med_size', '600 x 800'),
-      '#description' => t('The medium size image derivative is default is <b>600 x 800</b> (maximum width by maximum height), not effect relative ratio. Please use a number space the lowercase letter x space and a number.<br/><span style="color:red">WARNING: This will set the size for all medium sized images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
-      '#required' => TRUE,
-    ),
-    'derivative_tn_size' => array(
-      '#type' => 'textfield',
-      '#title' => t('Derivative TN Size'),
-      '#default_value' => $get_default_value('derivative_tn_size', '200 x 200'),
-      '#description' => t('The TN size image derivative is default is <b>200 x 200</b> (maximum width by maximum height), not effect relative ratio. Please use a number space the lowercase letter x space and a number.<br/><span style="color:red">WARNING: This will set the size for all thumbnail images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
-      '#required' => TRUE,
-    ),
   );
+  $form['islandora_large_image_thumbnail_fieldset'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Thumbnail'),
+    '#description' => t('Settings for creating thumbnail derivatives<br/><span style="color:red">WARNING: This will set the size for all medium sized images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
+  );
+  $form['islandora_large_image_thumbnail_fieldset']['islandora_pdf_thumbnail_width'] = array(
+    '#type' => 'textfield',
+    '#attributes' => array(
+        ' type' => 'number',
+    ),
+    '#element_validate' => array('element_validate_number'),
+    '#title' => t('Maximum Width'),
+    '#description' => t('The width of the thumbnail in pixels.'),
+    '#default_value' => variable_get('islandora_pdf_thumbnail_width', 200),
+    '#size' => 5,
+  );
+  $form['islandora_large_image_thumbnail_fieldset']['islandora_pdf_thumbnail_height'] = array(
+    '#type' => 'textfield',
+    '#attributes' => array(
+        ' type' => 'number',
+    ),
+    '#element_validate' => array('element_validate_number'),
+    '#title' => t('Maximum Height'),
+    '#description' => t('The height of the thumbnail in pixels.'),
+    '#default_value' => variable_get('islandora_pdf_thumbnail_height', 200),
+    '#size' => 5,
+  );
+  $form['islandora_large_image_preview_fieldset'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Preview image'),
+    '#description' => t('Settings for creating preview image derivatives<br/><span style="color:red">WARNING: This will set the size for all medium sized images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
+  );
+  $form['islandora_large_image_preview_fieldset']['islandora_pdf_preview_width'] = array(
+    '#type' => 'textfield',
+    '#attributes' => array(
+        ' type' => 'number',
+    ),
+    '#element_validate' => array('element_validate_number'),
+    '#title' => t('Maximum Width'),
+    '#description' => t('The maximum width of the preview in pixels.'),
+    '#default_value' => variable_get('islandora_pdf_preview_width', 600),
+    '#size' => 5,
+  );
+  $form['islandora_large_image_preview_fieldset']['islandora_pdf_preview_height'] = array(
+    '#type' => 'textfield',
+    '#attributes' => array(
+        ' type' => 'number',
+    ),
+    '#element_validate' => array('element_validate_number'),
+    '#title' => t('Maximum Height'),
+    '#description' => t('The maximum height of the preview in pixels.'),
+    '#default_value' => variable_get('islandora_pdf_preview_height', 800),
+    '#size' => 5,
+  );
+
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_large_image_viewers', 'image/jp2');
   $form['actions'] = array(
@@ -117,8 +158,10 @@ function islandora_large_image_admin_submit($form, &$form_state) {
         'islandora_lossless',
         'islandora_large_image_uncompress_tiff',
         'islandora_kakadu_url',
-        'derivative_med_size',
-        'derivative_tn_size',
+        'islandora_pdf_thumbnail_height',
+        'islandora_pdf_thumbnail_width',
+        'islandora_pdf_preview_height',
+        'islandora_pdf_preview_width',
       );
       array_walk($variables, 'variable_del');
       break;
@@ -136,20 +179,23 @@ function islandora_update_kakadu_url_div($form, $form_state) {
  * Function to validate the inputs before saving.
  */
 function islandora_large_image_admin_validate($form, &$form_state) {
-  $check_size_inputs = ['derivative_med_size', 'derivative_tn_size'];
-  $non_number_found = 0;
+  $failed_checks = 0;
 
   // Checks to see if the values are exclusively numeric.
-  foreach ($check_size_inputs as $derivative_size => $form_state_values) {
-    $checking_numbers = explode(" x ", $form_state['values'][$form_state_values]);
-    foreach ($checking_numbers as $key => $value) {
-      if (!is_numeric($value) || count($checking_numbers) != 2) {
-        $non_number_found = 1;
-      }
-    }
+  if ($form['islandora_large_image_thumbnail_fieldset']['islandora_pdf_thumbnail_width']['#value'] <= 0) {
+    $failed_checks = 1;
+  }
+  if ($form['islandora_large_image_thumbnail_fieldset']['islandora_pdf_thumbnail_height']['#value'] <= 0) {
+    $failed_checks = 1;
+  }
+  if ($form['islandora_large_image_preview_fieldset']['islandora_pdf_preview_width']['#value'] <= 0) {
+    $failed_checks = 1;
+  }
+  if ($form['islandora_large_image_preview_fieldset']['islandora_pdf_preview_height']['#value'] <= 0) {
+    $failed_checks = 1;
   }
 
-  if ($non_number_found == 1) {
-    form_set_error('colour', t('The Derivative sizes must follow the expected format. #0000 x #0000'));
+  if ($failed_checks == 1) {
+    form_set_error('colour', t('The Derivative sizes must be numeric and be larger than zero.'));
   }
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -86,7 +86,7 @@ function islandora_large_image_admin(array $form, array &$form_state) {
       '#type' => 'textfield',
       '#title' => t('Derivative TN Size'),
       '#default_value' => $get_default_value('derivative_tn_size', '200 x 200'),
-      '#description' => t('The medium size image derivative is default is <b>600 x 800</b> (maximum width by maximum height), not effect relative ratio. Please use a number space the lowercase letter x space and a number.<br/><span style="color:red">WARNING: This will set the size for all thumbnail images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
+      '#description' => t('The TN size image derivative is default is <b>200 x 200</b> (maximum width by maximum height), not effect relative ratio. Please use a number space the lowercase letter x space and a number.<br/><span style="color:red">WARNING: This will set the size for all thumbnail images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
       '#required' => TRUE,
     ),
   );
@@ -142,7 +142,6 @@ function islandora_large_image_admin_validate($form, &$form_state) {
   // Checks to see if the values are exclusively numeric.
   foreach ($check_size_inputs as $derivative_size => $form_state_values) {
     $checking_numbers = explode(" x ", $form_state['values'][$form_state_values]);
-
     foreach ($checking_numbers as $key => $value) {
         if (!is_numeric($value) || count($checking_numbers) != 2 ){
           $non_number_found = 1;

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -133,19 +133,19 @@ function islandora_update_kakadu_url_div($form, $form_state) {
 }
 
 /**
-* Function to validate the inputs before saving.
-*/
+ * Function to validate the inputs before saving.
+ */
 function islandora_large_image_admin_validate($form, &$form_state) {
-  $check_size_inputs=['derivative_med_size','derivative_tn_size'];
-  $non_number_found=0;
+  $check_size_inputs = ['derivative_med_size', 'derivative_tn_size'];
+  $non_number_found = 0;
 
   // Checks to see if the values are exclusively numeric.
   foreach ($check_size_inputs as $derivative_size => $form_state_values) {
     $checking_numbers = explode(" x ", $form_state['values'][$form_state_values]);
     foreach ($checking_numbers as $key => $value) {
-        if (!is_numeric($value) || count($checking_numbers) != 2 ){
-          $non_number_found = 1;
-        }
+      if (!is_numeric($value) || count($checking_numbers) != 2) {
+        $non_number_found = 1;
+      }
     }
   }
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -75,6 +75,20 @@ function islandora_large_image_admin(array $form, array &$form_state) {
         ),
       ),
     ),
+    'derivative_med_size' => array(
+      '#type' => 'textfield',
+      '#title' => t('Derivative Medium Size'),
+      '#default_value' => $get_default_value('derivative_med_size', '600 x 800'),
+      '#description' => t('The medium size image derivative is default is <b>600 x 800</b> (maximum width by maximum height), not effect relative ratio. Please use a number space the lowercase letter x space and a number.<br/><span style="color:red">WARNING: This will set the size for all medium sized images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
+      '#required' => TRUE,
+    ),
+    'derivative_tn_size' => array(
+      '#type' => 'textfield',
+      '#title' => t('Derivative TN Size'),
+      '#default_value' => $get_default_value('derivative_tn_size', '200 x 200'),
+      '#description' => t('The medium size image derivative is default is <b>600 x 800</b> (maximum width by maximum height), not effect relative ratio. Please use a number space the lowercase letter x space and a number.<br/><span style="color:red">WARNING: This will set the size for all thumbnail images generated as a derivative. Regenerate derivatives to apply this setting to existing objects.</span>'),
+      '#required' => TRUE,
+    ),
   );
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_large_image_viewers', 'image/jp2');
@@ -103,6 +117,8 @@ function islandora_large_image_admin_submit($form, &$form_state) {
         'islandora_lossless',
         'islandora_large_image_uncompress_tiff',
         'islandora_kakadu_url',
+        'derivative_med_size',
+        'derivative_tn_size',
       );
       array_walk($variables, 'variable_del');
       break;
@@ -114,4 +130,25 @@ function islandora_large_image_admin_submit($form, &$form_state) {
  */
 function islandora_update_kakadu_url_div($form, $form_state) {
   return $form['islandora_kakadu_url'];
+}
+
+/**
+* Function to validate the inputs before saving.
+*/
+function islandora_large_image_admin_validate($form, &$form_state) {
+  $check_size_inputs=['derivative_med_size','derivative_tn_size'];
+  $non_number_found=0;
+
+  // Checks to see if the values are exclusively numeric.
+  foreach ($check_size_inputs as $derivative_size => $form_state_values) {
+    $checking_numbers = explode(" x ", $form_state['values'][$form_state_values]);
+    foreach ($checking_numbers as $key => $value) {
+        if (!is_numeric($value)){
+          $non_number_found = 1;
+        }
+    }
+  }
+  if ($non_number_found == 1) {
+    form_set_error('colour', t('The Derivative sizes must follow the expected format. #0000 x #0000'));
+  }
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -142,12 +142,14 @@ function islandora_large_image_admin_validate($form, &$form_state) {
   // Checks to see if the values are exclusively numeric.
   foreach ($check_size_inputs as $derivative_size => $form_state_values) {
     $checking_numbers = explode(" x ", $form_state['values'][$form_state_values]);
+
     foreach ($checking_numbers as $key => $value) {
-        if (!is_numeric($value)){
+        if (!is_numeric($value) || count($checking_numbers) != 2 ){
           $non_number_found = 1;
         }
     }
   }
+
   if ($non_number_found == 1) {
     form_set_error('colour', t('The Derivative sizes must follow the expected format. #0000 x #0000'));
   }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -84,7 +84,7 @@ function islandora_large_image_admin(array $form, array &$form_state) {
   $form['islandora_large_image_thumbnail_fieldset']['islandora_pdf_thumbnail_width'] = array(
     '#type' => 'textfield',
     '#attributes' => array(
-        ' type' => 'number',
+      'type' => 'number',
     ),
     '#element_validate' => array('element_validate_number'),
     '#title' => t('Maximum Width'),
@@ -95,7 +95,7 @@ function islandora_large_image_admin(array $form, array &$form_state) {
   $form['islandora_large_image_thumbnail_fieldset']['islandora_pdf_thumbnail_height'] = array(
     '#type' => 'textfield',
     '#attributes' => array(
-        ' type' => 'number',
+      'type' => 'number',
     ),
     '#element_validate' => array('element_validate_number'),
     '#title' => t('Maximum Height'),
@@ -111,7 +111,7 @@ function islandora_large_image_admin(array $form, array &$form_state) {
   $form['islandora_large_image_preview_fieldset']['islandora_pdf_preview_width'] = array(
     '#type' => 'textfield',
     '#attributes' => array(
-        ' type' => 'number',
+      'type' => 'number',
     ),
     '#element_validate' => array('element_validate_number'),
     '#title' => t('Maximum Width'),
@@ -122,7 +122,7 @@ function islandora_large_image_admin(array $form, array &$form_state) {
   $form['islandora_large_image_preview_fieldset']['islandora_pdf_preview_height'] = array(
     '#type' => 'textfield',
     '#attributes' => array(
-        ' type' => 'number',
+      'type' => 'number',
     ),
     '#element_validate' => array('element_validate_number'),
     '#title' => t('Maximum Height'),

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -159,7 +159,7 @@ function islandora_large_image_create_jpg_derivative(AbstractObject $object, $fo
 
     $uploaded_file = islandora_large_image_get_uploaded_file($object);
     $args = array();
-    $args[] = '-resize ' . escapeshellarg("600 x 800");
+    $args[] = '-resize ' . escapeshellarg(variable_get('derivative_med_size', "600 x 800"));
     $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
     $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JPG.jpg", $args);
     if ($derivative_file === FALSE) {
@@ -227,7 +227,7 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
       // Only apply colorspace changes if not in the RGB family.
       $args = array();
       $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
-      $args[] = '-resize ' . escapeshellarg("200 x 200");
+      $args[] = '-resize ' . escapeshellarg(variable_get('derivative_tn_size', "200 x 200"));
       $isrgb = stripos($colorspace, 'rgb');
       if ($isrgb === FALSE) {
         $args[] = '-colorspace sRGB';

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -159,7 +159,8 @@ function islandora_large_image_create_jpg_derivative(AbstractObject $object, $fo
 
     $uploaded_file = islandora_large_image_get_uploaded_file($object);
     $args = array();
-    $args[] = '-resize ' . escapeshellarg(variable_get('derivative_med_size', "600 x 800"));
+    $derivative_med_size = t('@width x @height', array('@width' => variable_get('islandora_pdf_preview_width', "600"), '@height' => variable_get('islandora_pdf_preview_height', "800")));
+    $args[] = '-resize ' . escapeshellarg($derivative_med_size);
     $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
     $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JPG.jpg", $args);
     if ($derivative_file === FALSE) {
@@ -226,8 +227,9 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
     else {
       // Only apply colorspace changes if not in the RGB family.
       $args = array();
+      $derivative_tn_size = t('@width x @height', array('@width' => variable_get('islandora_pdf_thumbnail_width', "200"), '@height' => variable_get('islandora_pdf_thumbnail_height', "200")));
+      $args[] = '-resize ' . escapeshellarg($derivative_tn_size);
       $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
-      $args[] = '-resize ' . escapeshellarg(variable_get('derivative_tn_size', "200 x 200"));
       $isrgb = stripos($colorspace, 'rgb');
       if ($isrgb === FALSE) {
         $args[] = '-colorspace sRGB';

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -159,7 +159,10 @@ function islandora_large_image_create_jpg_derivative(AbstractObject $object, $fo
 
     $uploaded_file = islandora_large_image_get_uploaded_file($object);
     $args = array();
-    $derivative_med_size = t('@width x @height', array('@width' => variable_get('islandora_pdf_preview_width', "600"), '@height' => variable_get('islandora_pdf_preview_height', "800")));
+    $derivative_med_size = t('@width x @height', array(
+      '@width' => variable_get('islandora_pdf_preview_width', "600"),
+      '@height' => variable_get('islandora_pdf_preview_height', "800"),
+    ));
     $args[] = '-resize ' . escapeshellarg($derivative_med_size);
     $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
     $derivative_file = islandora_large_image_imagemagick_convert($uploaded_file, "temporary://{$base_name}_JPG.jpg", $args);
@@ -227,7 +230,10 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
     else {
       // Only apply colorspace changes if not in the RGB family.
       $args = array();
-      $derivative_tn_size = t('@width x @height', array('@width' => variable_get('islandora_pdf_thumbnail_width', "200"), '@height' => variable_get('islandora_pdf_thumbnail_height', "200")));
+      $derivative_tn_size = t('@width x @height', array(
+        '@width' => variable_get('islandora_pdf_thumbnail_width', "200"),
+        '@height' => variable_get('islandora_pdf_thumbnail_height', "200"),
+      ));
       $args[] = '-resize ' . escapeshellarg($derivative_tn_size);
       $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
       $isrgb = stripos($colorspace, 'rgb');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2334

# What does this Pull Request do?
Adds the global variable lookup and assignment as well as documentation. 

# What's new?
Global variables derivative_tn_size & derivative_med_size

This looks for these variables, if they are not available the module uses the current sizes already hard coded in. 

# How should this be tested?
Ingest a large object before this PR. View both the medium sized jpg and the TN and take note of their sizes. Medium size image should be no larger than 600 x 800 and TN should be no larger than 200 x 200. 

After you switch to this PR follow the instructions on the README.md to set values. 

An easy way to see the difference is set the TN to something dramatic (like 900 x 900) and click regenerate TN derivative from the manage datastream page. Now the image should be the size you specified.

# Additional Notes:
N/A 

# Interested parties
@Islandora/7-x-1-x-committers
