### PR TITLE
Gone pink with the TN

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -229,6 +229,7 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
       $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
       $args[] = '-resize ' . escapeshellarg("200 x 200");
       $args[] = '-strip';
+      $args[] = '-interlace Plane';
       $isrgb = stripos($colorspace, 'rgb');
       if ($isrgb === FALSE) {
         $args[] = '-colorspace sRGB';

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -228,6 +228,7 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
       $args = array();
       $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
       $args[] = '-resize ' . escapeshellarg("200 x 200");
+      $args[] = '-strip';
       $isrgb = stripos($colorspace, 'rgb');
       if ($isrgb === FALSE) {
         $args[] = '-colorspace sRGB';


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2388

A known issue with ICC profile in Firefox (reported in 2010) causes some images to display as pink. 

> The QCMS color management system introduced in Firefox 3.5 only supports ICC version 2 color profiles, not version 4. [ICC color correction in Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3.5/ICC_color_correction_in_Firefox)

Either ICC profiles and/or embedded issues with embedded tag values could cause these errors and can be easily stripped out of the TN. The ICC profile metadata embedded in the TN and any tags that aren't essential can be stripped out during generation/regeneration to correct this. 

# What does this Pull Request do?

1. Corrects the pink thumbnail issue for TN images displaying in Firefox.
2. Adds progressive scan to the TN image to improve page performance (slightly).

# What's new?
For islandora's large image create tn derivative
The "convert" command added these 2 arguments -strip -interlace Plane

# How should this be tested?
Here is an [example Tiff](https://jira.duraspace.org/secure/attachment/19254/icc_profile_causes_pink_tn.tiff) that causes this issue to test with.

1. Ingest large image objects (both jp2 & tif)
2. regenerate TN for both
Pull in this PR and go through the previous steps again in any order

# Additional Notes:

**Example of a working profile**
> Properties:
    icc:description: sRGB IEC61966-2.1
    icc:manufacturer: IEC http://www.iec.ch
    icc:model: IEC 61966-2.1 Default RGB colour space - sRGB

**Example of a profile that causes irregularity with some browsers**
> Properties:
    icc:description: SF_R (UMAX PowerLook 2100XL)

# Interested parties
@Islandora/7-x-1-x-committers
