### PR TITLE
ImageMagick JP2 derivs need effective compression

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -445,7 +445,7 @@ function islandora_large_image_add_datastream(AbstractObject $object, $dsid, $fi
  */
 function islandora_large_image_get_args($lossless) {
   if ($lossless) {
-    $args[] = " -define numrlvls=6";
+    $args[] = " -define jp2:numrlvls=6";
     $args[] = " -define jp2:tilewidth=1024";
     $args[] = " -define jp2:tileheight=1024";
     $args[] = " -define jp2:rate=1.0";
@@ -455,10 +455,10 @@ function islandora_large_image_get_args($lossless) {
     $args[] = " -define jp2:mode=int";
   }
   else {
-    $args[] = "-define numrlvls=7";
+    $args[] = "-define jp2:numrlvls=7";
     $args[] = "-define jp2:tilewidth=1024";
     $args[] = "-define jp2:tileheight=1024";
-    $args[] = "-define jp2:quality=42";
+    $args[] = "-define jp2:rate=16";
     $args[] = "-define jp2:prg=rpcl";
     $args[] = "-define jp2:mode=int";
     $args[] = "-define jp2:prcwidth=16383";

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -458,7 +458,7 @@ function islandora_large_image_get_args($lossless) {
     $args[] = "-define numrlvls=7";
     $args[] = "-define jp2:tilewidth=1024";
     $args[] = "-define jp2:tileheight=1024";
-    $args[] = "-define jp2:rate=0.02348";
+    $args[] = "-define jp2:quality=42";
     $args[] = "-define jp2:prg=rpcl";
     $args[] = "-define jp2:mode=int";
     $args[] = "-define jp2:prcwidth=16383";


### PR DESCRIPTION
**JIRA Ticket**: (pending account creation)

Other notes:
* https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/islandora-dev/Kx8fRm57aFw/WNmXhlv5DAAJ
* https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/islandora-isle/QDbRDQuhSWU/6LjUroymBgAJ
* https://github.com/ImageMagick/ImageMagick/issues/1662 and https://github.com/ImageMagick/ImageMagick/issues/1676 indicate some ongoing related issue


# What does this Pull Request do?

Currently turning of Kakadu results in 6-10x filesize increase for JP2 derivatives. This isn't because OpenJPEG (what is being delegated through ImageMagick to handle JP2 creation) is terrible, it's because there's some issue with the `rate` parameter we've historically used. For non-lossless non-Kakadu JP2 generation we should be using 'quality' not 'rate' and we will have similar results to the Kakadu output.

All of this matters because of the Oracle Java license change, accelerating an existing desire to wipe Oracle Java by removing Djatoka, and Kakadu along with it. With this compression fix, it seems like there really isn't much detriment to running a full open-source stack.

# What's new?
The fix is a one-liner, switching from `rate` to `quality`. Quality is on a range of 0-100, similar to the Kakadu `rate` which is on a range of 0.0-1.0. Based on experimentation, I found a `quality` of 42 corresponded almost exactly to Kakadu's `rate=0.5` (the default). Supporting evidence:

Baseline/target (Kakadu):
```
root@b99b89eb709e:/var/www/html/testing# exiftool -s -ee -g1 -u -n -D kdu_compress_test_default_args.jp2
---- ExifTool ----
- ExifToolVersion : 10.80
---- System ----
- FileName : kdu_compress_test_default_args.jp2
- Directory : .
- FileSize : 1053090
- FileModifyDate : 2019:09:03 13:21:07+00:00
- FileAccessDate : 2019:09:03 13:21:06+00:00
- FileInodeChangeDate : 2019:09:03 13:21:07+00:00
- FilePermissions : 644
---- File ----
- FileType : JP2
- FileTypeExtension : JP2
- MIMEType : image/jp2
---- Jpeg2000 ----
0 MajorBrand : jp2
1 MinorVersion : 0.0.0
2 CompatibleBrands : jp2
0 ImageHeight : 3483
4 ImageWidth : 4833
8 NumberOfComponents : 1
10 BitsPerComponent : 7
11 Compression : 7
0 ColorSpecMethod : 1
1 ColorSpecPrecedence : 0
2 ColorSpecApproximation : 0
3 ColorSpace : 17
0 DisplayYResolution : 0.2756042
4 DisplayXResolution : 0.2756042
8 DisplayYResolutionUnit : 5
9 DisplayXResolutionUnit : 5
---- Composite ----
- ImageSize : 4833x3483
- Megapixels : 16.833339
```

1.2 MB output at 42% quality (Imagemagick):
```
root@b99b89eb709e:/var/www/html/testing# exiftool -s -ee -g1 -u -n -D convert_test_quality42.jp2
---- ExifTool ----
- ExifToolVersion : 10.80
---- System ----
- FileName : convert_test_quality42.jp2
- Directory : .
- FileSize : 1189058
- FileModifyDate : 2019:09:03 13:40:06+00:00
- FileAccessDate : 2019:09:03 13:41:30+00:00
- FileInodeChangeDate : 2019:09:03 13:40:06+00:00
- FilePermissions : 644
---- File ----
- FileType : JP2
- FileTypeExtension : JP2
- MIMEType : image/jp2
---- Jpeg2000 ----
0 MajorBrand : jp2
1 MinorVersion : 0.0.0
2 CompatibleBrands : jp2
0 ImageHeight : 3483
4 ImageWidth : 4833
8 NumberOfComponents : 1
10 BitsPerComponent : 7
11 Compression : 7
0 ColorSpecMethod : 1
1 ColorSpecPrecedence : 0
2 ColorSpecApproximation : 0
3 ColorSpace : 17
---- Composite ----
- ImageSize : 4833x3483
- Megapixels : 16.833339
```
# How should this be tested?

Ok, so the toggle for Kakadu/non-Kakadu is available at "/admin/islandora/solution_pack_config/large_image"

You'll want to generate some (e.g. TIF -> JP2) derivatives with Kakadu on, and then off, and compare output. If you want to play with this on the command line, here are the relevant commands:

**Current IM:** `convert Z_LARGE_IMAGE_TEST.tiff -define numrlvls=7 -define jp2:tilewidth=1024 -define jp2:tileheight=1024 -define jp2:rate=0.02348 -define jp2:prg=rpcl -define jp2:mode=int -define jp2:prcwidth=16383 -define jp2:prcheight=16383 -define jp2:cblkwidth=64 -define jp2:cblkheight=64 -define jp2:sop convert_test_args_from_get_args.jp2`
**Replaced IM:** `convert Z_LARGE_IMAGE_TEST.tiff -define numrlvls=7 -define jp2:tilewidth=1024 -define jp2:tileheight=1024 -define jp2:quality=42 -define jp2:prg=rpcl -define jp2:mode=int -define jp2:prcwidth=16383 -define jp2:prcheight=16383 -define jp2:cblkwidth=64 -define jp2:cblkheight=64 -define jp2:sop convert_test_quality_42.jp2`
**Kakadu:** `kdu_compress -i Z_LARGE_IMAGE_TEST.tiff -o kdu_compress_test_default_args.jp2 -rate 0.5 Clayers=1 Clevels=7 "Cprecincts={256,256},{256,256},{256,256},{128,128},{128,128},{64,64},{64,64},{32,32},{16,16}" "Corder=RPCL" "ORGgen_plt=yes" "ORGtparts=R" "Cblk={32,32}" Cuse_sop=yes`

This was my primary test object: https://github.com/Born-Digital-US/isle-behat/tree/master/features/assets/Large-Image 

# Additional Notes:
I can't think of any side effects from this. Anyone who generated un-necessarily large IM-sourced JP2 derivatives should probably go back and delete/regenerate.

# Interested parties
I guess this would just go into 7.x and wait for the next release @whikloj ? Tagging a few more interested parties: @DonRichards @dwk2 @DiegoPino @bseeger
